### PR TITLE
Add range indexing test (with boundschecking)

### DIFF
--- a/src/arrays/ArrayBenchmarks.jl
+++ b/src/arrays/ArrayBenchmarks.jl
@@ -18,6 +18,7 @@ include("sumindex.jl")
         int_arrs = (makearrays(Int32, 3, 5)..., makearrays(Int32, 300, 500)...)
         float_arrs = (makearrays(Float32, 3, 5)..., makearrays(Float32, 300, 500)...)
         arrays = (int_arrs..., float_arrs...)
+        bigrngs = (1:10^8, 10^8:-1:1, 1.0:1e8, linspace(1,2,10^7))
     end
     @benchmarks begin
         [(:sumelt, string(typeof(A)), size(A)) => perf_sumelt(A) for A in arrays]
@@ -28,6 +29,7 @@ include("sumindex.jl")
         [(:sumrange, string(typeof(A)), size(A)) => perf_sumrange(A) for A in arrays]
         [(:sumlogical, string(typeof(A)), size(A)) => perf_sumlogical(A) for A in arrays]
         [(:sumvector, string(typeof(A)), size(A)) => perf_sumvector(A) for A in arrays]
+        [(:sumrangebc, string(typeof(A)), size(A)) => perf_sumrangebc(A) for A in bigrngs]
     end
     @tags "array" "sum" "indexing" "simd"
 end

--- a/src/arrays/sumindex.jl
+++ b/src/arrays/sumindex.jl
@@ -60,6 +60,14 @@ function perf_sumrange(A)
     return s
 end
 
+function perf_sumrangebc{T}(r::Range{T})
+    s = zero(T)
+    for i = 1:length(r)
+        s += r[i] # bounds-checking is deliberately on, don't use `for a in r`
+    end
+    s
+end
+
 function perf_sumlogical(A)
     s = zero(eltype(A)) + zero(eltype(A))
     nrows = size(A, 1)


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/16078

The tests didn't run successfully for me:
```jl
 julia> Pkg.test("BaseBenchmarks")
INFO: Testing BaseBenchmarks
ERROR: LoadError: LoadError: LoadError: LoadError: UndefVarError: ExecutionResults not defined
 in include(::ASCIIString) at ./boot.jl:233
 in include_from_node1(::ASCIIString) at ./loading.jl:426
 in include(::ASCIIString) at ./boot.jl:233
 in include_from_node1(::ASCIIString) at ./loading.jl:426
 in eval(::Module, ::Any) at ./boot.jl:236
 [inlined code] from ./sysimg.jl:11
 in require(::Symbol) at ./loading.jl:357
 in include(::ASCIIString) at ./boot.jl:233
 in include_from_node1(::ASCIIString) at ./loading.jl:426
 in eval(::Module, ::Any) at ./boot.jl:236
 [inlined code] from ./sysimg.jl:11
 in require(::Symbol) at ./loading.jl:357
 in include(::ASCIIString) at ./boot.jl:233
 in include_from_node1(::UTF8String) at ./loading.jl:426
 in process_options(::Base.JLOptions) at ./client.jl:263
 in _start() at ./client.jl:319
while loading /home/tim/.julia/v0.5/BenchmarkTrackers/src/metrics.jl, in expression starting on line 21
while loading /home/tim/.julia/v0.5/BenchmarkTrackers/src/BenchmarkTrackers.jl, in expression starting on line 38
while loading /home/tim/.julia/v0.5/BaseBenchmarks/src/BaseBenchmarks.jl, in expression starting on line 3
while loading /home/tim/.julia/v0.5/BaseBenchmarks/test/runtests.jl, in expression starting on line 1
=======================================================[ ERROR: BaseBenchmarks ]========================================================

failed process: Process(`/home/tim/src/julia-0.5/usr/bin/julia -Cnative -J/home/tim/src/julia-0.5/usr/lib/julia/sys.so --compile=yes --check-bounds=yes --code-coverage=none --color=yes /home/tim/.julia/v0.5/BaseBenchmarks/test/runtests.jl`, ProcessExited(1)) [1]

========================================================================================================================================
ERROR: Base.Pkg.PkgError("BaseBenchmarks had test errors")
 [inlined code] from ./strings/io.jl:33
 in #test#49(::Bool, ::Any, ::Array{AbstractString,1}) at ./pkg/entry.jl:678
 [inlined code] from ./promotion.jl:229
 in (::Base.Pkg.Dir.##2#3{Array{Any,1},Base.Pkg.Entry.#test,Tuple{Array{AbstractString,1}}})() at ./pkg/dir.jl:31
 in cd(::Base.Pkg.Dir.##2#3{Array{Any,1},Base.Pkg.Entry.#test,Tuple{Array{AbstractString,1}}}, ::ASCIIString) at ./file.jl:48
 in #cd#1(::Array{Any,1}, ::Any, ::Any, ::Array{AbstractString,1}, ::Vararg{Array{AbstractString,1}}) at ./pkg/dir.jl:31
 in #test#3(::Bool, ::Any, ::ASCIIString, ::Vararg{ASCIIString}) at ./pkg.jl:228
 in eval(::Module, ::Any) at ./boot.jl:236
```
Doesn't appear to have anything to do with what I added, but I don't know if this is correct.