### PR TITLE
Broadcast benchmarks

### DIFF
--- a/src/BaseBenchmarks.jl
+++ b/src/BaseBenchmarks.jl
@@ -14,6 +14,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.memory_tolerance = 0.01
 const PARAMS_PATH = joinpath(dirname(@__FILE__), "..", "etc", "params.jld")
 const SUITE = BenchmarkGroup()
 const MODULES = Dict("array" => :ArrayBenchmarks,
+                     "broadcast" => :BroadcastBenchmarks,
                      "io" => :IOBenchmarks,
                      "linalg" => :LinAlgBenchmarks,
                      "micro" => :MicroBenchmarks,
@@ -36,7 +37,9 @@ function load!(group::BenchmarkGroup, id::AbstractString; tune::Bool = true)
     eval(BaseBenchmarks, :(include($modpath)))
     modsuite = eval(BaseBenchmarks, modsym).SUITE
     group[id] = modsuite
-    tune && loadparams!(modsuite, JLD.load(PARAMS_PATH, id), :evals)
+    tune && jldopen(PARAMS_PATH, "r") do file
+        JLD.exists(file, id) && loadparams!(modsuite, JLD.load(file, id), :evals)
+    end
     return group
 end
 

--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -52,9 +52,9 @@ g = addgroup!(SUITE, "dotop", ["broadcast!", "array"])
 perf_op_bcast!(r, x) = @dotcompat r .= 3 .* x .- 4 .* x.^2 .+ x .* x .- x .^ 3
 perf_op_bcast!(R, x, y) = @dotcompat R .= 3 .* x .- 4 .* y.^2 .+ x .* y .- x .^ 3
 
-g["dotop", "Float64", size(r), 1] = @benchmarkable perf_op_bcast!($r, $z)
-g["dotop", "Float64", size(R), 2] = @benchmarkable perf_op_bcast!($R, $x, $y)
-g["dotop", "Float64", size(r), 2] = @benchmarkable perf_op_bcast!($r, $z, 17.3)
+g["Float64", size(r), 1] = @benchmarkable perf_op_bcast!($r, $z)
+g["Float64", size(R), 2] = @benchmarkable perf_op_bcast!($R, $x, $y)
+g["Float64", size(r), 2] = @benchmarkable perf_op_bcast!($r, $z, 17.3)
 
 ###########################################################################
 

--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -1,0 +1,61 @@
+module BroadcastBenchmarks
+
+include(joinpath(dirname(@__FILE__), "..", "utils", "RandUtils.jl"))
+
+using .RandUtils
+using BenchmarkTools
+using Compat
+
+const SUITE = BenchmarkGroup()
+
+# work around lack of Compat support for .= (Compat.jl issue #285)
+if VERSION < v"0.5.0-dev+5575" #17510
+    macro dotcompat(ex)
+        if Meta.isexpr(ex, :comparison, 3) && ex.args[2] == :.=
+            :(copy!($(ex.args[1]), $(ex.args[3])))
+        else
+            ex
+        end
+    end
+else
+    macro dotcompat(ex)
+        ex
+    end
+end
+
+###########################################################################
+
+g = addgroup!(SUITE, "fusion", ["broadcast!", "array"])
+
+f(x,y) = 3x - 4y^2
+h(x) = 6x + 2x^2 - 5
+perf_bcast!(r, x) = @dotcompat r .= @compat h.(f.(x, h.(x)))
+perf_bcast!(R, x, y) = @dotcompat R .= @compat h.(f.(x, h.(y)))
+perf_bcast!(R, x, y, z) = @dotcompat R .= @compat f.(X, f.(x, y))
+
+x = randvec(10^3)
+y = randvec(10^3)'
+z = randvec(10^6)
+X = randmat(10^3)
+R = Array(Float64, length(x),length(y))
+r = similar(z)
+
+g["fusion", "Float64", size(r), 1] = @benchmarkable perf_bcast!($r, $z)
+g["fusion", "Float64", size(R), 2] = @benchmarkable perf_bcast!($R, $x, $y)
+g["fusion", "Float64", size(R), 3] = @benchmarkable perf_bcast!($R, $X, $x, $y)
+g["fusion", "Float64", size(r), 2] = @benchmarkable perf_bcast!($r, $z, 17.3)
+
+###########################################################################
+
+g = addgroup!(SUITE, "dotop", ["broadcast!", "array"])
+
+perf_op_bcast!(r, x) = @dotcompat r .= 3 .* x .- 4 .* x.^2 .+ x .* x .- x .^ 3
+perf_op_bcast!(R, x, y) = @dotcompat R .= 3 .* x .- 4 .* y.^2 .+ x .* y .- x .^ 3
+
+g["dotop", "Float64", size(r), 1] = @benchmarkable perf_op_bcast!($r, $z)
+g["dotop", "Float64", size(R), 2] = @benchmarkable perf_op_bcast!($R, $x, $y)
+g["dotop", "Float64", size(r), 2] = @benchmarkable perf_op_bcast!($r, $z, 17.3)
+
+###########################################################################
+
+end # module

--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -58,4 +58,14 @@ g["dotop", "Float64", size(r), 2] = @benchmarkable perf_op_bcast!($r, $z, 17.3)
 
 ###########################################################################
 
+g = addgroup!(SUITE, "sparse", ["broadcast", "array"])
+
+s = samesprand(10^7, 1e-3, randn)
+perf_sparse_op(s) = sqrt.(abs.(s .* 2))
+perf_sparse_op(s,t) = f.(s,t)
+g["sparse", size(s), 1] = @benchmarkable perf_sparse_op($s)
+g["sparse", size(s), 2] = @benchmarkable perf_sparse_op($s, $s)
+
+###########################################################################
+
 end # module

--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -60,11 +60,20 @@ g["dotop", "Float64", size(r), 2] = @benchmarkable perf_op_bcast!($r, $z, 17.3)
 
 g = addgroup!(SUITE, "sparse", ["broadcast", "array"])
 
-s = samesprand(10^7, 1e-3, randn)
 perf_sparse_op(s) = sqrt.(abs.(s .* 2))
 perf_sparse_op(s,t) = f.(s,t)
+
+if VERSION < v"0.5.0-dev+763"
+    s = samesprand(10^7, 1, 1e-3, randn)
+else
+    s = samesprand(10^7, 1e-3, randn)
+end
+S = samesprand(10^3, 10^3, 1e-3, randn)
+
 g["sparse", size(s), 1] = @benchmarkable perf_sparse_op($s)
 g["sparse", size(s), 2] = @benchmarkable perf_sparse_op($s, $s)
+g["sparse", size(S), 1] = @benchmarkable perf_sparse_op($S)
+g["sparse", size(S), 2] = @benchmarkable perf_sparse_op($S, $S)
 
 ###########################################################################
 

--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -40,10 +40,10 @@ X = randmat(10^3)
 R = Array(Float64, length(x),length(y))
 r = similar(z)
 
-g["fusion", "Float64", size(r), 1] = @benchmarkable perf_bcast!($r, $z)
-g["fusion", "Float64", size(R), 2] = @benchmarkable perf_bcast!($R, $x, $y)
-g["fusion", "Float64", size(R), 3] = @benchmarkable perf_bcast!($R, $X, $x, $y)
-g["fusion", "Float64", size(r), 2] = @benchmarkable perf_bcast!($r, $z, 17.3)
+g["Float64", size(r), 1] = @benchmarkable perf_bcast!($r, $z)
+g["Float64", size(R), 2] = @benchmarkable perf_bcast!($R, $x, $y)
+g["Float64", size(R), 3] = @benchmarkable perf_bcast!($R, $X, $x, $y)
+g["Float64", size(r), 2] = @benchmarkable perf_bcast!($r, $z, 17.3)
 
 ###########################################################################
 
@@ -70,10 +70,10 @@ else
 end
 S = samesprand(10^3, 10^3, 1e-3, randn)
 
-g["sparse", size(s), 1] = @benchmarkable perf_sparse_op($s)
-g["sparse", size(s), 2] = @benchmarkable perf_sparse_op($s, $s)
-g["sparse", size(S), 1] = @benchmarkable perf_sparse_op($S)
-g["sparse", size(S), 2] = @benchmarkable perf_sparse_op($S, $S)
+g[size(s), 1] = @benchmarkable perf_sparse_op($s)
+g[size(s), 2] = @benchmarkable perf_sparse_op($s, $s)
+g[size(S), 1] = @benchmarkable perf_sparse_op($S)
+g[size(S), 2] = @benchmarkable perf_sparse_op($S, $S)
 
 ###########################################################################
 

--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -60,8 +60,8 @@ g["dotop", "Float64", size(r), 2] = @benchmarkable perf_op_bcast!($r, $z, 17.3)
 
 g = addgroup!(SUITE, "sparse", ["broadcast", "array"])
 
-perf_sparse_op(s) = sqrt.(abs.(s .* 2))
-perf_sparse_op(s,t) = f.(s,t)
+perf_sparse_op(s) = @compat sqrt.(abs.(s .* 2))
+perf_sparse_op(s,t) = @compat f.(s,t)
 
 if VERSION < v"0.5.0-dev+763"
     s = samesprand(10^7, 1, 1e-3, randn)


### PR DESCRIPTION
This adds a new suite (`broadcast`) of benchmarks testing the new broadcast-fusion functionality, the upcoming dot-operator=broadcast change, and broadcast on sparse vectors, for JuliaLang/julia#16285.