### PR TITLE
Fix benchmark that needed state reset for every evaluation instead of every sample

### DIFF
--- a/src/io/IOBenchmarks.jl
+++ b/src/io/IOBenchmarks.jl
@@ -46,12 +46,12 @@ teststrings = [randstring(RandUtils.SEED, 32) for i=1:10^3]
 teststrings_buf = serialized_buf(teststrings)
 
 g["serialize", "Vector{String}"] = @benchmarkable serialize(io, $teststrings) setup=(io=IOBuffer())
-g["deserialize", "Vector{String}"] = @benchmarkable deserialize($teststrings_buf) setup=(seek($teststrings_buf, 0))
+g["deserialize", "Vector{String}"] = @benchmarkable (seek($teststrings_buf, 0); deserialize($teststrings_buf))
 
 testdata = rand(RandUtils.SEED,1000,1000)
 testdata_buf = serialized_buf(testdata)
 
 g["serialize", "Matrix{Float64}"] = @benchmarkable serialize(io, $testdata) setup=(io=IOBuffer())
-g["deserialize", "Matrix{Float64}"] = @benchmarkable deserialize($testdata_buf) setup=(seek($testdata_buf, 0))
+g["deserialize", "Matrix{Float64}"] = @benchmarkable (seek($testdata_buf, 0); deserialize($testdata_buf))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,8 @@ using Base.Test
 
 BaseBenchmarks.loadall!()
 
-@test begin warmup(BaseBenchmarks.SUITE); true end
+@test begin
+    run(BaseBenchmarks.SUITE, verbose = true, samples = 1,
+        evals = 2, gctrial = false, gcsample = false);
+    true
+end


### PR DESCRIPTION
Additionally, alter the test command to ensure this case is accounted for.