### PR TITLE
update laplace benchmark to use fused dotops

### DIFF
--- a/src/broadcast/BroadcastBenchmarks.jl
+++ b/src/broadcast/BroadcastBenchmarks.jl
@@ -1,27 +1,13 @@
 module BroadcastBenchmarks
 
-include(joinpath(dirname(@__FILE__), "..", "utils", "RandUtils.jl"))
+include(joinpath("..", "utils", "RandUtils.jl"))
+include(joinpath("..", "utils", "CompatUtils.jl"))
 
-using .RandUtils
+using .RandUtils, .CompatUtils
 using BenchmarkTools
 using Compat
 
 const SUITE = BenchmarkGroup()
-
-# work around lack of Compat support for .= (Compat.jl issue #285)
-if VERSION < v"0.5.0-dev+5575" #17510
-    macro dotcompat(ex)
-        if Meta.isexpr(ex, :comparison, 3) && ex.args[2] == :.=
-            :(copy!($(esc(ex.args[1])), $(esc(ex.args[3]))))
-        else
-            esc(ex)
-        end
-    end
-else
-    macro dotcompat(ex)
-        esc(ex)
-    end
-end
 
 ###########################################################################
 

--- a/src/problem/Laplacian.jl
+++ b/src/problem/Laplacian.jl
@@ -4,6 +4,9 @@ using Compat
 
 import Compat: UTF8String, view
 
+include(joinpath("..", "utils", "CompatUtils.jl"))
+using .CompatUtils
+
 ################################
 # Sparse Matrix * Dense Vector #
 ################################
@@ -76,7 +79,7 @@ function perf_laplace_iter_vec(N)
     Niter = 2^10
     dx2 = dy2 = 0.1*0.1
     for i = 1:Niter
-        u[2:N-1, 2:N-1] = ((u[1:N-2, 2:N-1] + u[3:N, 2:N-1])*dy2 + (u[2:N-1, 1:N-2] + u[2:N-1, 3:N])*dx2) * (1 / (2*(dx2+dy2)))
+        @dotcompat u[2:N-1, 2:N-1] .= ((u[1:N-2, 2:N-1] .+ u[3:N, 2:N-1]).*dy2 .+ (u[2:N-1, 1:N-2] .+ u[2:N-1, 3:N]).*dx2) .* (1 / (2*(dx2+dy2)))
     end
     return u
 end
@@ -86,8 +89,13 @@ function perf_laplace_iter_sub(N)
     u[1,:] = 1
     Niter = 2^10
     dx2 = dy2 = 0.1*0.1
+    u0 = view(u, 2:N-1, 2:N-1)
+    u1 = view(u, 1:N-2, 2:N-1)
+    u2 = view(u, 3:N,   2:N-1)
+    u3 = view(u, 2:N-1, 1:N-2)
+    u4 = view(u, 2:N-1, 3:N)
     for i = 1:Niter
-        u[2:N-1, 2:N-1] = ((view(u, 1:N-2, 2:N-1) + view(u,3:N, 2:N-1))*dy2 + (view(u,2:N-1, 1:N-2) + view(u, 2:N-1, 3:N))*dx2) * (1 / (2*(dx2+dy2)))
+        @dotcompat u0 .= ((u1 .+ u2).*dy2 .+ (u3 .+ u4).*dx2) .* (1 / (2*(dx2+dy2)))
     end
     return u
 end

--- a/src/shootout/nbody_vec.jl
+++ b/src/shootout/nbody_vec.jl
@@ -6,20 +6,8 @@
 
 module NBodyVec
 
-# work around lack of Compat support for .= (Compat.jl issue #285)
-if VERSION < v"0.5.0-dev+5575" #17510
-    macro dotcompat(ex)
-        if Meta.isexpr(ex, :comparison, 3) && ex.args[2] == :.=
-            :(copy!($(esc(ex.args[1])), $(esc(ex.args[3]))))
-        else
-            esc(ex)
-        end
-    end
-else
-    macro dotcompat(ex)
-        esc(ex)
-    end
-end
+include(joinpath("..", "utils", "CompatUtils.jl"))
+using .CompatUtils
 
 # Constants
 const solar_mass = 4 * pi * pi

--- a/src/utils/CompatUtils.jl
+++ b/src/utils/CompatUtils.jl
@@ -1,0 +1,20 @@
+module CompatUtils
+
+export @dotcompat
+
+# work around lack of Compat support for .= (Compat.jl issue #285)
+if VERSION < v"0.5.0-dev+5575" #17510
+    macro dotcompat(ex)
+        if Meta.isexpr(ex, :comparison, 3) && ex.args[2] == :.=
+            :(copy!($(esc(ex.args[1])), $(esc(ex.args[3]))))
+        else
+            esc(ex)
+        end
+    end
+else
+    macro dotcompat(ex)
+        esc(ex)
+    end
+end
+
+end


### PR DESCRIPTION
This updates the laplace benchmark to use fused dotops in the vectorized versions as discussed in JuliaLang/julia#1168