### PR TITLE
array benchmarks causes dirty git

### DIFF
--- a/src/array/.gitignore
+++ b/src/array/.gitignore
@@ -1,0 +1,1 @@
+hdindexing.jl


### PR DESCRIPTION
commit message:
> The file src/array/hdindexing.jl is generated dynamically by
> ArrayBenchmarks.jl when the array benchmarks are executed. This
> caused git status to be dirty.
> 
> This commit adds a src/array/.gitignore which explicitly ignores
> that file.

When playing around with this package (as you do), I noticed that the array benchmarks generate a file called `hdindexing.jl` here: https://github.com/JuliaCI/BaseBenchmarks.jl/blob/master/src/array/ArrayBenchmarks.jl#L89-L90

Executing just the `"array"` benchmarks or `Pkg.test` cause a dirty git, since it is not deleted after the benchmarks were run. A entry in `.gitignore` seems like an easy band-aid.
