### PR TITLE
RFC add matrix types, add sqrtm benchmarks

### DIFF
--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -7,6 +7,7 @@ using BenchmarkTools
 using Compat
 
 import Compat: UTF8String, view
+import Base.LinAlg: UnitUpperTriangular
 
 const SUITE = BenchmarkGroup(["array"])
 

--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -85,6 +85,12 @@ for s in SIZES
         g["cumsum!", T, s] = @benchmarkable cumsum!($arr, $arr)
     end
 
+    for M in (UpperTriangular, UnitUpperTriangular, NPDUpperTriangular, Hermitian)
+        mstr = typename(M)
+        m = linalgmat(M, s)
+        g["sqrtm", mstr, s] = @benchmarkable sqrtm($m)
+    end
+
 end
 
 for b in values(g)
@@ -134,24 +140,6 @@ for s in SIZES
     g["schurfact", mstr, s] = @benchmarkable schurfact($m)
     g["qr", mstr, s]        = @benchmarkable qr($m)
     g["qrfact", mstr, s]    = @benchmarkable qrfact($m)
-end
-
-for b in values(g)
-    b.params.time_tolerance = 0.45
-end
-
-##############
-# operations #
-##############
-
-g = addgroup!(SUITE, "operations")
-
-for M in (UpperTriangular, UnitUpperTriangular, NPDUpperTriangular, Hermitian)
-    mstr = typename(M)
-    for s in SIZES
-        m = linalgmat(M, s)
-        g["sqrtm", mstr, s] = @benchmarkable sqrtm($m)
-    end
 end
 
 for b in values(g)

--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -25,6 +25,7 @@ linalgmat(::Type{Tridiagonal}, s) = Tridiagonal(randvec(s-1), randvec(s), randve
 linalgmat(::Type{SymTridiagonal}, s) = SymTridiagonal(randvec(s), randvec(s-1))
 linalgmat(::Type{UpperTriangular}, s) = UpperTriangular(randmat(s))
 linalgmat(::Type{LowerTriangular}, s) = LowerTriangular(randmat(s))
+linalgmat(::Type{UnitUpperTriangular}, s) = UnitUpperTriangular(randmat(s))
 
 function linalgmat(::Type{Hermitian}, s)
     A = randmat(s)
@@ -32,21 +33,17 @@ function linalgmat(::Type{Hermitian}, s)
     return Hermitian(A + A')
 end
 
-function linalgmat{M}(::Type{M}, s, f::Function)
-    A = linalgmat(M, s)
-    for i in 1:s
-        A[i,i] = f(A[i,i])
-    end
-    return A
-end
-linalgmat{T}(::Type{T}, s, identity) = linalgmat(T, s)
-
-linalgmat(::Type{UnitUpperTriangular}, s) = linalgmat(UpperTriangular, s, x -> 1)
-
 # Non-positive-definite upper-triangular matrix
 type NPDUpperTriangular
 end
-linalgmat(::Type{NPDUpperTriangular}, s) = linalgmat(UpperTriangular, s, x -> randn()*x)
+function linalgmat(::Type{NPDUpperTriangular}, s)
+    A = linalgmat(UpperTriangular, s)
+    rr = samerand(s)
+    for i in 1:s
+        A[i,i] = (2*rr[i]-1)*A[i,i]
+    end
+    return A
+end
 typename(::Type{NPDUpperTriangular}) = "NPDUpperTriangular"
 
 


### PR DESCRIPTION
Start benchmarking `sqrtm`, cf. https://github.com/JuliaLang/julia/pull/20214
Add `UnitUpperTriangular` and `NPDUpperTriangular` (NPD = non-positive-definite) matrices to the testing