### PR TITLE
bench mapreduce with array accesses

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -60,7 +60,7 @@ for (A, str) in (arrays_iter..., ranges_iter...)
     g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view($A)
     g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view($A)
     if ndims(A) == 2
-        g["mapr_access", str]    = @benchmarkable perf_mapr_access($A) #20517
+        g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = $setup_mapr_access #20517
     end
     if ndims(A) <= 2
         g["sumcolon", str]       = @benchmarkable perf_sumcolon($A)

--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -60,7 +60,7 @@ for (A, str) in (arrays_iter..., ranges_iter...)
     g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view($A)
     g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view($A)
     if ndims(A) == 2
-        g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = $setup_mapr_access #20517
+        g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = (B, zz, n = setup_mapr_access($A)) #20517
     end
     if ndims(A) <= 2
         g["sumcolon", str]       = @benchmarkable perf_sumcolon($A)

--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -59,6 +59,9 @@ for (A, str) in (arrays_iter..., ranges_iter...)
     g["sumeach_view", str]       = @benchmarkable perf_sumeach_view($A)
     g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view($A)
     g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view($A)
+    if ndims(A) == 2
+        g["mapr_access", str]    = @benchmarkable perf_mapr_access($A) #20517
+    end
     if ndims(A) <= 2
         g["sumcolon", str]       = @benchmarkable perf_sumcolon($A)
         g["sumrange", str]       = @benchmarkable perf_sumrange($A)

--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -60,7 +60,7 @@ for (A, str) in (arrays_iter..., ranges_iter...)
     g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view($A)
     g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view($A)
     if ndims(A) == 2
-        g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = begin B, zz, n = setup_mapr_access($A) end #20517
+        g["mapr_access", str]    = @benchmarkable perf_mapr_access($A, B, zz, n) setup = begin B, zz, n = setup_mapr_access($A) end #20517
     end
     if ndims(A) <= 2
         g["sumcolon", str]       = @benchmarkable perf_sumcolon($A)

--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -60,7 +60,7 @@ for (A, str) in (arrays_iter..., ranges_iter...)
     g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view($A)
     g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view($A)
     if ndims(A) == 2
-        g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = (B, zz, n = setup_mapr_access($A)) #20517
+        g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = begin B, zz, n = setup_mapr_access($A) end #20517
     end
     if ndims(A) <= 2
         g["sumcolon", str]       = @benchmarkable perf_sumcolon($A)

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -191,12 +191,13 @@ function perf_ind2sub(sz, lrange)
     si, sj, sk
 end
 
-function perf_mapr_access(A)
+setup_mapr_access = quote
     z = zero(eltype(A))
     zz = z*z
     n = Base.LinAlg.checksquare(A)
     B = Vector{typeof(zz)}(n)
-
+end
+function perf_mapr_access(A, B, zz, n) #20517
     @inbounds for j in 1:n
         B[j] = mapreduce(k -> A[j,k]*A[k,j], +, zz, 1:j)
     end

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -191,11 +191,12 @@ function perf_ind2sub(sz, lrange)
     si, sj, sk
 end
 
-setup_mapr_access = quote
+function setup_mapr_access(A)
     z = zero(eltype(A))
     zz = z*z
     n = Base.LinAlg.checksquare(A)
     B = Vector{typeof(zz)}(n)
+    B, zz, n
 end
 function perf_mapr_access(A, B, zz, n) #20517
     @inbounds for j in 1:n

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -193,7 +193,7 @@ end
 
 function setup_mapr_access(A)
     z = zero(eltype(A))
-    zz = z*z
+    zz = mapreduce(z -> z*z, +, [z]) # z = z*z, with any promotion from mapreduce
     n = Base.LinAlg.checksquare(A)
     B = Vector{typeof(zz)}(n)
     B, zz, n

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -194,7 +194,7 @@ end
 function setup_mapr_access(A)
     z = zero(eltype(A))
     zz = mapreduce(z -> z*z, +, [z]) # z = z*z, with any promotion from mapreduce
-    n = Base.LinAlg.checksquare(A)
+    n = minimum(size(A))
     B = Vector{typeof(zz)}(n)
     B, zz, n
 end

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -191,6 +191,18 @@ function perf_ind2sub(sz, lrange)
     si, sj, sk
 end
 
+function perf_mapr_access(A)
+    z = zero(eltype(A))
+    zz = z*z
+    n = Base.LinAlg.checksquare(A)
+    B = Vector{typeof(zz)}(n)
+
+    @inbounds for j in 1:n
+        B[j] = mapreduce(k -> A[j,k]*A[k,j], +, zz, 1:j)
+    end
+    B
+end
+
 ##########################
 # supporting definitions #
 ##########################


### PR DESCRIPTION
Cf. https://github.com/JuliaLang/julia/issues/20517:
`mapreduce` can be much slower than the equivalent `for`-loop, currently mostly coming from an inference bug https://github.com/JuliaLang/julia/issues/15276 related to `Core.box`.

This benchmark would allow keeping an eye on this realistic code pattern. If that is what you had in mind, @stevengj ?