### PR TITLE
increase time budget for linalg benchmarks so that more samples can be collected

### DIFF
--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -95,6 +95,8 @@ end
 
 for b in values(g)
     b.params.time_tolerance = 0.45
+    b.params.samples = 100
+    b.params.seconds = 20
 end
 
 ##################


### PR DESCRIPTION
The one that needs this the most is `sqrtm`. It's been really noisy lately, so I looked into why. It turns out it takes a full second for a single execution, so it was only being executed once before hitting the default time budget. I bet this is also the case for a couple of other noisy benchmarks. I'll look at the sparse benchmarks as well, and potentially make the same change there.

It's easy to tune the time budget per benchmark/group, so we should really start doing so if we're going to add long-running benchmarks. I should also start checking for this when reviewing new BaseBenchmarks PRs. We can also raise the default time budget and lower the sample ceiling (`10000` is probably overkill for most benchmarks).