### PR TITLE
add benchmarks for fixed size arrays

### DIFF
--- a/src/tuple/TupleBenchmarks.jl
+++ b/src/tuple/TupleBenchmarks.jl
@@ -51,4 +51,133 @@ for s in TUPLE_SUM_SIZES, T in TUPLE_SUM_TYPES
     g["sumelt", "TupleWrapper", s, T] = @benchmarkable sum_tuple($tupwrap) time_tolerance=0.40
 end
 
+#####################
+# Fixed Size Arrays #
+#####################
+
+# Short fixed size array implementation
+
+@compat abstract type FixedArray{T, N} <: AbstractArray{T, N} end
+
+@compat Base.IndexStyle(::Type{<: FixedArray}) = IndexLinear()
+Base.getindex(fsa::FixedArray, i::Int) = fsa.data[i]
+
+
+immutable FixedVector{L, T} <: FixedArray{T, 1}
+    data::NTuple{L, T}
+end
+
+Base.size{L}(::FixedVector{L}) = (L,)
+Base.size{L, T}(::Type{FixedVector{L, T}}) = (L,)
+Base.length{L}(::FixedVector{L}) = L
+
+
+immutable FixedMatrix{R, C, T, RC} <: FixedArray{T, 2}
+    data::NTuple{RC, T}
+end
+
+Base.size{R, C}(::FixedMatrix{R, C}) = (R, C)
+Base.size{R, C, T, RC}(::Type{FixedMatrix{R, C, T, RC}}) = (R, C)
+Base.length{R, C, T, RC}(::FixedMatrix{R, C, T, RC}) = RC
+
+
+# Reductions
+
+@inline function perf_reduce(op, a::FixedArray)
+    if length(a) == 1
+        return a[1]
+    else
+        s = op(a[1], a[2])
+        for j = 3:length(a)
+            s = op(s, a[j])
+        end
+        return s
+    end
+end
+
+perf_minimum(a::FixedArray) = perf_reduce(min, a)
+
+
+@inline function perf_reduce(op, v0, a::FixedArray)
+    if length(a) == 0
+        return v0
+    else
+        s = v0
+        @inbounds @simd for j = 1:length(a)
+            s = op(s, a[j])
+        end
+        return s
+    end
+end
+
+perf_sum{T}(v::FixedArray{T}) = perf_reduce(+, zero(T), v)
+
+
+@inline function perf_mapreduce(f, op, v0, a1::FixedArray)
+    if length(a1) == 0
+        return v0
+    else
+        s = op(v0, f(a1[1]))
+        for j = 2:length(a1)
+            s = op(s, f(a1[j]))
+        end
+        return s
+    end
+end
+
+perf_sumabs2{T}(a::FixedArray{T}) = perf_mapreduce(abs2, +, zero(T), a)
+
+
+# Linear Algebra
+
+@generated function perf_matvec{R, C, T}(A::FixedMatrix{R, C, T}, b::FixedVector{C, T})
+    sA = size(A)
+    sB = size(b)
+    exprs = Expr(:tuple, [reduce((ex1,ex2) -> :(+($ex1,$ex2)),
+                [:(A[$(sub2ind(sA, k, j))]*b[$j]) for j = 1:sA[2]]) for k = 1:sA[1]]...)
+    return quote
+        @inbounds return FixedVector{R, T}($exprs)
+    end
+end
+
+@generated function perf_matmat{R1, R2, C, T}(A::FixedMatrix{R1, C, T}, B::FixedMatrix{C, R2, T})
+    sA = size(A)
+    sB = size(B)
+    exprs =  Expr(:tuple, [reduce((ex1,ex2) -> :(+($ex1,$ex2)),
+                [:(A[$(sub2ind(sA, k1, j))] * B[$(sub2ind(sB, j, k2))]) for j = 1:sA[2]]) for k1 = 1:sA[1], k2 = 1:sB[2]]...)
+    result_type = FixedMatrix{R1, R2, T, (R1 * R2)}
+    return quote
+        @inbounds return $result_type($exprs)
+    end
+end
+
+if VERSION >= v"0.5"
+
+# Benchmarks #
+##############
+v2, v4, v8, v16 = [FixedVector((rand(i)...)) for i in (2, 4, 8, 16)]
+m2x2, m4x4, m8x8, m16x16 = [FixedMatrix{i,i, Float64, i*i}((rand(i*i)...)) for i in (2, 4, 8, 16)]
+
+
+# Reductions
+g = addgroup!(SUITE, "reduction", ["tuple"])
+
+for mv in (v2, v4, v8, v16, m2x2, m4x4, m8x8, m16x16)
+    g["sum", size(mv)] = @benchmarkable perf_sum($mv)
+    g["sumabs", size(mv)] = @benchmarkable perf_sumabs2($mv)
+    g["minimum", size(mv)] = @benchmarkable perf_minimum($mv)
+end
+
+# Linear algebra
+
+g = addgroup!(SUITE, "linear algebra", ["tuple"])
+
+for (m, v) in zip((m2x2, m4x4, m8x8, m16x16), (v2, v4, v8, v16 ))
+    g["matvec", size(m), size(v)] = @benchmarkable perf_matvec($m, $v)
+    g["matmat", size(m), size(m)] = @benchmarkable perf_matmat($m, $m)
+end
+
+end # version
+
+
 end # module


### PR DESCRIPTION
Add Benchmarks for a small fixed size array (FSA) implementation (based on tuples) with some reduce functionality and mat * mat/vect. 
I feel this is good to have here since we tuples are the de facto way that FSA's are implemented.

I borrowed some of your linear algebra code @andyferris. Hope you don't mind.