### PR TITLE
Update sumindex.jl

### DIFF
--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -193,7 +193,7 @@ end
 
 function setup_mapr_access(A)
     z = zero(eltype(A))
-    zz = mapreduce(z -> z*z, +, [z]) # z = z*z, with any promotion from mapreduce
+    zz = sum(z -> z * z, [z]) # z = z*z, with any promotion from sum
     n = minimum(size(A))
     B = Vector{typeof(zz)}(n)
     B, zz, n


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/22825 will change the behavior of `mapreduce` to never promote, so to retain the previous behavior it must be changed to `sum`.