### PR TITLE
Prepare SparseFEM benchmark to changes to find() on Julia master

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 BenchmarkTools 0.2.1
-Compat 0.37.0
+Compat 0.44.0

--- a/src/problem/SparseFEM.jl
+++ b/src/problem/SparseFEM.jl
@@ -20,7 +20,7 @@ end
 
 # timing of assembly, slice and solve
 function perf_sparse_fem(N)
-    Ifree = get_free(N)
+    Ifree = [LinearIndices((N, N))[i] for i in get_free(N)]
     # assembly
     A = fdlaplacian(N)
     # boundary condition


### PR DESCRIPTION
`find` will soon return cartesian indices (https://github.com/JuliaLang/julia/pull/24774), so this benchmark needs to convert them to linear indices. Unfortunately, `LinearIndices` currently does not allow indexing with an array, so we need to use `map`.