### PR TITLE
Fix numerous deprecation warnings

### DIFF
--- a/src/array/generate_kernel.jl
+++ b/src/array/generate_kernel.jl
@@ -1,14 +1,14 @@
 # generate the spatial kernel for an n-dimensional wave equation solver
 include("generate_loops.jl")
 
-# This function generates code to solve the n-dimensional 
+# This function generates code to solve the n-dimensional
 # constant coefficient wave equation in first order form, for dimensions 1
 # to maxdim.  It uses 4th order accuate finite difference stencils.
-# The function perf_hdindexing5 loops over all dimensions and calls the 
+# The function perf_hdindexing5 loops over all dimensions and calls the
 # function kernel5 to evaluate the stencils at each point.  Dispatch on the
 # array dimension ties the n different solvers together.
 function make_stencil(fname, maxdim)
-# generate kernels and loops for arrays of dimension 2 to maxdim + 1 and write 
+# generate kernels and loops for arrays of dimension 2 to maxdim + 1 and write
 # to file named fname
 
   stencil = ["1/12", "-2/3", "0", "2/3", "-1/12"]
@@ -20,7 +20,7 @@ function make_stencil(fname, maxdim)
   str = generate_kernel(maxdim, stencil, neq)
   str *= "\n"
   str *= generate_loops(maxdim, npts)
-  
+
   f = open(fname, "w")
   println(f, str)
   close(f)
@@ -74,7 +74,7 @@ function generate_body(maxdim, stencil, neq)
       str *= string(var_name, " = ", stencil_dim)*"\n"
 
     end
-  
+
     # sum the results into the receiving arrays
     kernel_assembly = getKernelAssembly(maxdim, eq, neq - eq + 1)
     str *= kernel_assembly*"\n"
@@ -85,7 +85,7 @@ function generate_body(maxdim, stencil, neq)
 end
 
 
-function getStencil(maxdim::Integer, stencil, dim::Integer, src_eq::Integer, 
+function getStencil(maxdim::Integer, stencil, dim::Integer, src_eq::Integer,
                     second_line_indent::String="")
 
 # Generates a string that multiplies the given stencil coefficients by
@@ -141,7 +141,7 @@ function getStencil(maxdim::Integer, stencil, dim::Integer, src_eq::Integer,
     coeff_str = string( " "^padding, "(", stencil_pt, ")")
 
     str_pt = indentlevel*coeff_str*"*u_i[ "
-    
+
     # insert all indices before dim
     for i=1:(dim-1)
       idx_i = "d$i"
@@ -149,7 +149,7 @@ function getStencil(maxdim::Integer, stencil, dim::Integer, src_eq::Integer,
     end
 
     # insert index dim and modifier
-    
+
     # figure out if this should be a plus or minus
     stencil_offset_inner = abs(stencil_offset)
     if stencil_offset < 0
@@ -235,8 +235,8 @@ function getKernelSignature(dim::Integer, npts::Integer)
   kernel_name = string("kernel", npts)
   array_typetag = string("::AbstractArray{T,", dim+1, "}")
 
-  str = string("function ", kernel_name, "{T}(idx, ")
-  str *= string("u_i", array_typetag, ", u_ip1", array_typetag, ")\n")
+  str = string("function ", kernel_name, "(idx, ")
+  str *= string("u_i", array_typetag, ", u_ip1", array_typetag, ") where T\n")
 
   return str
 end

--- a/src/array/generate_loops.jl
+++ b/src/array/generate_loops.jl
@@ -21,7 +21,7 @@ function generateLoops(N, npts)
 
   np1 = N + 1
   str = ""
-  str *= "function perf_hdindexing$npts{T}(u_i::AbstractArray{T, $np1}, u_ip1::AbstractArray{T, $np1})\n"
+  str *= "function perf_hdindexing$npts(u_i::AbstractArray{T, $np1}, u_ip1::AbstractArray{T, $np1}) where T\n"
 
   indent = "  "
 

--- a/src/array/subarray.jl
+++ b/src/array/subarray.jl
@@ -1,7 +1,7 @@
 if VERSION >= v"0.7.0-DEV.1660"
     _maxind(A) = indmax(A).I
 else
-    _maxind(A) = ind2sub(size(A), indmax(A))
+    _maxind(A) = CartesianIndices(Compat.axes(A))[indmax(A)].I
 end
 
 function perf_lucompletepivCopy!(A)

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -39,7 +39,7 @@ function perf_sumlinear(A)
 end
 function perf_sumcartesian(A)
     s = zero(eltype(A))
-    for I in CartesianRange(size(A))
+    for I in CartesianIndices(size(A))
         val = Base.unsafe_getindex(A, I)
         s += val
     end
@@ -115,7 +115,7 @@ function perf_sumlinear_view(A)
 end
 function perf_sumcartesian_view(A)
     s = zero(eltype(A))
-    @inbounds @simd for I in CartesianRange(size(A))
+    @inbounds @simd for I in CartesianIndices(size(A))
         val = view(A, I)
         s += val[]
     end
@@ -172,27 +172,21 @@ function perf_sumvector_view(A)
 end
 
 
-if VERSION >= v"0.7.0-DEV.3025"
-    _ind2sub(sz, l) = Tuple(CartesianIndices(sz)[l])
-    _sub2ind(sz, i, j, k) = LinearIndices(sz)[i, j, k]
-else
-    _ind2sub(sz, l) = ind2sub(sz, l)
-    _sub2ind(sz, i, j, k) = sub2ind(sz, i, j, k)
-end
-
 function perf_sub2ind(sz, irange, jrange, krange)
+    linear = LinearIndices(sz)
     s = 0
     for k in krange, j in jrange, i in irange
-        ind = _sub2ind(sz, i, j, k)
+        ind = linear[i, j, k]
         s += ind
     end
     s
 end
 
 function perf_ind2sub(sz, lrange)
+    cart = CartesianIndices(sz)
     si = sj = sk = 0
     for l in lrange
-        i, j, k = _ind2sub(sz, l)
+        i, j, k = cart[l].I  # TODO: change to Tuple(cart[l])
         si += i
         sj += j
         sk += k

--- a/src/collection/CollectionBenchmarks.jl
+++ b/src/collection/CollectionBenchmarks.jl
@@ -260,6 +260,7 @@ set_tolerance!(g)
 g = addgroup!(SUITE, "optimizations", ["Dict", "Set", "BitSet", "Vector"])
 
 for T in (Nothing, Bool, Int8, UInt16)
+    local v
     v::Vector{T} = T === Nothing ? Vector{Nothing}(100000) :
                                    rand(MT, one(T):typemax(T), 100000)
     tstr = string(T)

--- a/src/collection/CollectionBenchmarks.jl
+++ b/src/collection/CollectionBenchmarks.jl
@@ -261,7 +261,7 @@ g = addgroup!(SUITE, "optimizations", ["Dict", "Set", "BitSet", "Vector"])
 
 for T in (Nothing, Bool, Int8, UInt16)
     local v
-    v::Vector{T} = T === Nothing ? Vector{Nothing}(100000) :
+    v::Vector{T} = T === Nothing ? Vector{Nothing}(uninitialized, 100000) :
                                    rand(MT, one(T):typemax(T), 100000)
     tstr = string(T)
     g["Dict", "abstract", tstr] = @benchmarkable Dict($(map(Pair, v, v)))

--- a/src/collection/CollectionBenchmarks.jl
+++ b/src/collection/CollectionBenchmarks.jl
@@ -1,6 +1,7 @@
 module CollectionBenchmarks
 
 using BenchmarkTools
+using Compat
 
 # TODO: Remove once Compat has BitSet
 if !isdefined(Base, :BitSet)
@@ -258,15 +259,15 @@ set_tolerance!(g)
 # cf. issue #20903 and PR #21964
 g = addgroup!(SUITE, "optimizations", ["Dict", "Set", "BitSet", "Vector"])
 
-for T in (Void, Bool, Int8, UInt16)
-    v::Vector{T} = T === Void ? Vector{Void}(100000) :
-                                rand(MT, one(T):typemax(T), 100000)
+for T in (Nothing, Bool, Int8, UInt16)
+    v::Vector{T} = T === Nothing ? Vector{Nothing}(100000) :
+                                   rand(MT, one(T):typemax(T), 100000)
     tstr = string(T)
     g["Dict", "abstract", tstr] = @benchmarkable Dict($(map(Pair, v, v)))
     g["Dict", "concrete", tstr] = @benchmarkable Dict{$T,$T}($(map(Pair, v, v)))
     g["Set",  "abstract", tstr] = @benchmarkable Set($v)
     g["Set",  "concrete", tstr] = @benchmarkable Set{$T}($v)
-    if T === Void
+    if T === Nothing
         g["Vector", "abstract", tstr] = @benchmarkable Vector($v)
         g["Vector", "concrete", tstr] = @benchmarkable Vector{$T}($v)
     elseif T !== Bool && (!(T <: Unsigned) || VERSION >= v"0.7.0-")

--- a/src/union/UnionBenchmarks.jl
+++ b/src/union/UnionBenchmarks.jl
@@ -9,7 +9,7 @@ using Compat
 const SUITE = BenchmarkGroup()
 
 ########################
-# array Union{T, Void} #
+# array Union{T, Nothing} #
 ########################
 
 g = addgroup!(SUITE, "array")
@@ -17,7 +17,7 @@ g = addgroup!(SUITE, "array")
 const VEC_LENGTH = 1000
 
 _zero(::Type{T}) where {T} = zero(T)
-_zero(::Type{Union{T, Void}}) where {T} = zero(T)
+_zero(::Type{Union{T, Nothing}}) where {T} = zero(T)
 
 function perf_sum(X::AbstractArray{T}) where T
     s = _zero(T) + _zero(T)
@@ -53,10 +53,10 @@ for T in (Bool, Int8, Int64, Float32, Float64, BigInt, BigFloat, Complex{Float64
     end
 
     # 10% of missing values
-    X = Vector{Union{T, Void}}(Vector{T}(samerand(S, VEC_LENGTH)))
-    Y = Vector{Union{T, Void}}(Vector{T}(samerand(S, VEC_LENGTH)))
-    X2 = Vector{Union{T, Void}}(Vector{T}(samerand(S, VEC_LENGTH)))
-    Y2 = Vector{Union{T, Void}}(Vector{T}(samerand(S, VEC_LENGTH)))
+    X = Vector{Union{T, Nothing}}(Vector{T}(samerand(S, VEC_LENGTH)))
+    Y = Vector{Union{T, Nothing}}(Vector{T}(samerand(S, VEC_LENGTH)))
+    X2 = Vector{Union{T, Nothing}}(Vector{T}(samerand(S, VEC_LENGTH)))
+    Y2 = Vector{Union{T, Nothing}}(Vector{T}(samerand(S, VEC_LENGTH)))
     X2[samerand(VEC_LENGTH) .> .9] = nothing
     Y2[samerand(VEC_LENGTH) .> .9] = nothing
 


### PR DESCRIPTION
Not tested locally on 0.6, so let's allow the tests to tell me whether I've broken anything. But Compat seems to have been very well updated (thanks to all who did that) for these changes.

Fixes many, but not all, of the issues #158. The rest might be better handled by others. However, I believe @ararslan mentioned that nanosoldier has been slower because of the warnings; I bet this will get the worst of the slowdowns (any indexing-related deprecations are usually fatal for performance).