### PR TITLE
adapt to the post-jazz world

### DIFF
--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -90,7 +90,11 @@ for s in SIZES
     C = zeros(Float32, s, s)
     A = randmat(s)
     B = randmat(s)
-    g["A_mul_B!", "Matrix{Float32}", "Matrix{Float64}", "Matrix{Float64}", s] = @benchmarkable A_mul_B!($C, $A, $B)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["mul!", "Matrix{Float32}", "Matrix{Float64}", "Matrix{Float64}", s] = @benchmarkable Base.LinAlg.mul!($C, $A, $B)
+    else
+        g["mul!", "Matrix{Float32}", "Matrix{Float64}", "Matrix{Float64}", s] = @benchmarkable A_mul_B!($C, $A, $B)
+    end
 
     for T in [Int32, Int64, Float32, Float64]
         arr = samerand(T, s)

--- a/src/parallel/ThreadedStockCorr.jl
+++ b/src/parallel/ThreadedStockCorr.jl
@@ -5,13 +5,26 @@ module ThreadedStockCorr
 using Base.Threads
 
 # Run paths in parallel (has to be in its own function due to #10718)
-function runpath!(n, Wiener, CorrWiener, SA, SB, T, UpperTriangle, k11, k12, k21, k22, rngs)
-    @threads for i = 1:n
-        randn!(rngs[threadid()], Wiener)
-        A_mul_B!(CorrWiener, Wiener, UpperTriangle)
-        @simd for j = 2:T
-            @inbounds SA[j, i] = SA[j-1, i] * exp(k11 + k12*CorrWiener[j-1, 1])
-            @inbounds SB[j, i] = SB[j-1, i] * exp(k21 + k22*CorrWiener[j-1, 2])
+if VERSION >= v"0.7.0-DEV.3204"
+    function runpath!(n, Wiener, CorrWiener, SA, SB, T, UpperTriangle, k11, k12, k21, k22, rngs)
+        @threads for i = 1:n
+            randn!(rngs[threadid()], Wiener)
+            Base.LinAlg.mul!(CorrWiener, Wiener, UpperTriangle)
+            @simd for j = 2:T
+                @inbounds SA[j, i] = SA[j-1, i] * exp(k11 + k12*CorrWiener[j-1, 1])
+                @inbounds SB[j, i] = SB[j-1, i] * exp(k21 + k22*CorrWiener[j-1, 2])
+            end
+        end
+    end
+else
+    function runpath!(n, Wiener, CorrWiener, SA, SB, T, UpperTriangle, k11, k12, k21, k22, rngs)
+        @threads for i = 1:n
+            randn!(rngs[threadid()], Wiener)
+            A_mul_B!(CorrWiener, Wiener, UpperTriangle)
+            @simd for j = 2:T
+                @inbounds SA[j, i] = SA[j-1, i] * exp(k11 + k12*CorrWiener[j-1, 1])
+                @inbounds SB[j, i] = SB[j-1, i] * exp(k21 + k22*CorrWiener[j-1, 2])
+            end
         end
     end
 end

--- a/src/sparse/SparseBenchmarks.jl
+++ b/src/sparse/SparseBenchmarks.jl
@@ -154,28 +154,55 @@ g = addgroup!(SUITE, "matmul")
 # mixed sparse-dense matmul #
 #---------------------------#
 
-using Base.LinAlg: *, A_mul_B!,
-    A_mul_Bt,  A_mul_Bc,  A_mul_Bt!,  A_mul_Bc!,
-    At_mul_B,  Ac_mul_B,  At_mul_B!,  Ac_mul_B!,
-    At_mul_Bt, Ac_mul_Bc, At_mul_Bt!, Ac_mul_Bc!
+if VERSION >= v"0.7.0-DEV.3204"
+    using Base.LinAlg: *, mul!
+else
+    using Base.LinAlg: *, A_mul_B!,
+        A_mul_Bt,  A_mul_Bc,  A_mul_Bt!,  A_mul_Bc!,
+        At_mul_B,  Ac_mul_B,  At_mul_B!,  Ac_mul_B!,
+        At_mul_Bt, Ac_mul_Bc, At_mul_Bt!, Ac_mul_Bc!
+end    
 
-function allocmats_ds(om, ok, on, s, nnzc, T)
-    m, k, n = map(x -> Int(s*x), (om, ok, on))
-    densemat, sparsemat = samerand(T, m, k), samesprand(T, k, n, nnzc/k)
-    tdensemat, tsparsemat = transpose(densemat), transpose(sparsemat)
-    destmat = similar(densemat, m, n)
-    return m, k, n, destmat,
-        densemat, sparsemat,
-        tdensemat, tsparsemat
-end
-function allocmats_sd(om, ok, on, s, nnzc, T)
-    m, k, n = map(x -> Int(s*x), (om, ok, on))
-    densemat, sparsemat = samerand(T, k, m), samesprand(T, n, k, nnzc/n)
-    tdensemat, tsparsemat = transpose(densemat), transpose(sparsemat)
-    destmat = similar(densemat, n, m)
-    return m, k, n, destmat,
-        densemat, sparsemat,
-        tdensemat, tsparsemat
+if VERSION >= v"0.7.0-DEV.3204"
+    function allocmats_ds(om, ok, on, s, nnzc, T)
+        m, k, n = map(x -> Int(s*x), (om, ok, on))
+        densemat, sparsemat = samerand(T, m, k), samesprand(T, k, n, nnzc/k)
+        tdensemat = transpose!(similar(densemat, reverse(size(densemat))), densemat)
+        tsparsemat = transpose!(similar(sparsemat, reverse(size(sparsemat))), sparsemat)
+        destmat = similar(densemat, m, n)
+        return m, k, n, destmat,
+            densemat, sparsemat,
+            tdensemat, tsparsemat
+    end
+    function allocmats_sd(om, ok, on, s, nnzc, T)
+        m, k, n = map(x -> Int(s*x), (om, ok, on))
+        densemat, sparsemat = samerand(T, k, m), samesprand(T, n, k, nnzc/n)
+        tdensemat = transpose!(similar(densemat, reverse(size(densemat))), densemat)
+        tsparsemat = transpose!(similar(sparsemat, reverse(size(sparsemat))), sparsemat)
+        destmat = similar(densemat, n, m)
+        return m, k, n, destmat,
+            densemat, sparsemat,
+            tdensemat, tsparsemat
+    end
+else
+    function allocmats_ds(om, ok, on, s, nnzc, T)
+        m, k, n = map(x -> Int(s*x), (om, ok, on))
+        densemat, sparsemat = samerand(T, m, k), samesprand(T, k, n, nnzc/k)
+        tdensemat, tsparsemat = transpose(densemat), transpose(sparsemat)
+        destmat = similar(densemat, m, n)
+        return m, k, n, destmat,
+            densemat, sparsemat,
+            tdensemat, tsparsemat
+    end
+    function allocmats_sd(om, ok, on, s, nnzc, T)
+        m, k, n = map(x -> Int(s*x), (om, ok, on))
+        densemat, sparsemat = samerand(T, k, m), samesprand(T, n, k, nnzc/n)
+        tdensemat, tsparsemat = transpose(densemat), transpose(sparsemat)
+        destmat = similar(densemat, n, m)
+        return m, k, n, destmat,
+            densemat, sparsemat,
+            tdensemat, tsparsemat
+    end
 end
 
 for (om, ok, on) in (# order of matmul dimensions m, k, and n
@@ -202,26 +229,52 @@ for (om, ok, on) in (# order of matmul dimensions m, k, and n
     #
     # # out-of-place dense-sparse ops, transpose variants, i.e. A[t]_mul_B[t](dense, sparse)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 1/2, 4, Float64)
-    g["A_mul_B",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $sparsemat)
-    g["A_mul_Bt",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bt($densemat, $tsparsemat)
-    g["At_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable At_mul_B($tdensemat, $sparsemat)
-    g["At_mul_Bt", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable At_mul_Bt($tdensemat, $tsparsemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_B",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $sparsemat)
+        g["A_mul_Bt",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $(Transpose(tsparsemat)))
+        g["At_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($(Transpose(tdensemat)), $sparsemat)
+        g["At_mul_Bt", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($(Transpose(tdensemat)), $(Transpose(tsparsemat)))
+    else
+        g["A_mul_B",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $sparsemat)
+        g["A_mul_Bt",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bt($densemat, $tsparsemat)
+        g["At_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable At_mul_B($tdensemat, $sparsemat)
+        g["At_mul_Bt", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable At_mul_Bt($tdensemat, $tsparsemat)
+    end    
     # in-place dense-sparse -> dense ops, transpose variants, i.e. A[t]_mul[t]!(dense, dense, sparse)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 4, 12, Float64)
-    g["A_mul_B!",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable A_mul_B!($destmat, $densemat, $sparsemat)
-    g["A_mul_Bt!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bt!($destmat, $densemat, $tsparsemat)
-    g["At_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable At_mul_B!($destmat, $tdensemat, $sparsemat)
-    g["At_mul_Bt!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable At_mul_Bt!($destmat, $tdensemat, $tsparsemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_B!",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $densemat, $sparsemat)
+        g["A_mul_Bt!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $densemat, $(Transpose(tsparsemat)))
+        g["At_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Transpose(tdensemat)), $sparsemat)
+        g["At_mul_Bt!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Transpose(tdensemat)), $(Transpose(tsparsemat)))
+    else
+        g["A_mul_B!",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable A_mul_B!($destmat, $densemat, $sparsemat)
+        g["A_mul_Bt!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bt!($destmat, $densemat, $tsparsemat)
+        g["At_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable At_mul_B!($destmat, $tdensemat, $sparsemat)
+        g["At_mul_Bt!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable At_mul_Bt!($destmat, $tdensemat, $tsparsemat)
+    end
     # out-of-place dense-sparse ops, adjoint variants, i.e. A[c]_mul_B[c](dense, sparse)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 1/2, 4, Complex{Float64})
-    g["A_mul_Bc",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bc($densemat, $tsparsemat)
-    g["Ac_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_B($tdensemat, $sparsemat)
-    g["Ac_mul_Bc", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_Bc($tdensemat, $tsparsemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_Bc",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $(Adjoint(tsparsemat)))
+        g["Ac_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($(Adjoint(tdensemat)), $sparsemat)
+        g["Ac_mul_Bc", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($(Adjoint(tdensemat)), $(Adjoint(tsparsemat)))
+    else
+        g["A_mul_Bc",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bc($densemat, $tsparsemat)
+        g["Ac_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_B($tdensemat, $sparsemat)
+        g["Ac_mul_Bc", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_Bc($tdensemat, $tsparsemat)
+    end        
     # in-place dense-sparse -> dense ops, adjoint variants, i.e. A[c]_mul[c]!(dense, dense, sparse)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 2, 8, Complex{Float64})
-    g["A_mul_Bc!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bc!($destmat, $densemat, $tsparsemat)
-    g["Ac_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_B!($destmat, $tdensemat, $sparsemat)
-    g["Ac_mul_Bc!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_Bc!($destmat, $tdensemat, $tsparsemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_Bc!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $densemat, $(Adjoint(tsparsemat)))
+        g["Ac_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Adjoint(tdensemat)), $sparsemat)
+        g["Ac_mul_Bc!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Adjoint(tdensemat)), $(Adjoint(tsparsemat)))
+    else
+        g["A_mul_Bc!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable A_mul_Bc!($destmat, $densemat, $tsparsemat)
+        g["Ac_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_B!($destmat, $tdensemat, $sparsemat)
+        g["Ac_mul_Bc!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable Ac_mul_Bc!($destmat, $tdensemat, $tsparsemat)
+    end
     #
     # for A[t|c]_mul_B[t|c][!]([dense,], sparse, dense) kernels,
     # the sparse matrix is n-by-k, or k-by-n for B(c|t) operations
@@ -231,26 +284,52 @@ for (om, ok, on) in (# order of matmul dimensions m, k, and n
     #
     # out-of-place sparse-dense ops, transpose variants, i.e. A[t]_mul_B[t](sparse, dense)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 1/2, 4, Complex{Float64})
-    g["A_mul_B",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $densemat)
-    g["A_mul_Bt",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bt($sparsemat, $tdensemat)
-    g["At_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable At_mul_B($tsparsemat, $densemat)
-    g["At_mul_Bt", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable At_mul_Bt($tsparsemat, $tdensemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_B",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $densemat)
+        g["A_mul_Bt",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $(Transpose(tdensemat)))
+        g["At_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($(Transpose(tsparsemat)), $densemat)
+        g["At_mul_Bt", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($(Transpose(tsparsemat)), $(Transpose(tdensemat)))
+    else
+        g["A_mul_B",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $densemat)
+        g["A_mul_Bt",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bt($sparsemat, $tdensemat)
+        g["At_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable At_mul_B($tsparsemat, $densemat)
+        g["At_mul_Bt", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable At_mul_Bt($tsparsemat, $tdensemat)
+    end
     # in-place sparse-dense -> dense ops, transpose variants, i.e. A[t|c]_mul_B[t|c]!(dense, sparse, dense)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 4, 12, Complex{Float64})
-    g["A_mul_B!",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable A_mul_B!($destmat, $sparsemat, $densemat)
-    g["A_mul_Bt!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bt!($destmat, $sparsemat, $tdensemat)
-    g["At_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable At_mul_B!($destmat, $tsparsemat, $densemat)
-    g["At_mul_Bt!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable At_mul_Bt!($destmat, $tsparsemat, $tdensemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_B!",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $sparsemat, $densemat)
+        g["A_mul_Bt!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $sparsemat, $(Transpose(tdensemat)))
+        g["At_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Transpose(tsparsemat)), $densemat)
+        g["At_mul_Bt!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Transpose(tsparsemat)), $(Transpose(tdensemat)))
+    else
+        g["A_mul_B!",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable A_mul_B!($destmat, $sparsemat, $densemat)
+        g["A_mul_Bt!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bt!($destmat, $sparsemat, $tdensemat)
+        g["At_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable At_mul_B!($destmat, $tsparsemat, $densemat)
+        g["At_mul_Bt!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable At_mul_Bt!($destmat, $tsparsemat, $tdensemat)
+    end
     # out-of-place sparse-dense ops, adjoint variants, i.e. A[c]_mul_B[c](sparse, dense)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 1/2, 4, Complex{Float64})
-    g["A_mul_Bc",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bc($sparsemat, $tdensemat)
-    g["Ac_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_B($tsparsemat, $densemat)
-    g["Ac_mul_Bc", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_Bc($tsparsemat, $tdensemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_Bc",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $(Adjoint(tdensemat)))
+        g["Ac_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($(Adjoint(tsparsemat)), $densemat)
+        g["Ac_mul_Bc", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($(Adjoint(tsparsemat)), $(Adjoint(tdensemat)))
+    else
+        g["A_mul_Bc",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bc($sparsemat, $tdensemat)
+        g["Ac_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_B($tsparsemat, $densemat)
+        g["Ac_mul_Bc", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_Bc($tsparsemat, $tdensemat)
+    end
     # in-place sparse-dense -> dense ops, adjoint variants, i.e. A[t|c]_mul_B[t|c]!(dense, sparse, dense)
     m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 2, 8, Complex{Float64})
-    g["A_mul_Bc!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bc!($destmat, $sparsemat, $tdensemat)
-    g["Ac_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_B!($destmat, $tsparsemat, $densemat)
-    g["Ac_mul_Bc!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_Bc!($destmat, $tsparsemat, $tdensemat)
+    if VERSION >= v"0.7.0-DEV.3204"
+        g["A_mul_Bc!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $sparsemat, $(Adjoint(tdensemat)))
+        g["Ac_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Adjoint(tsparsemat)), $densemat)
+        g["Ac_mul_Bc!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Adjoint(tsparsemat)), $(Adjoint(tdensemat)))
+    else
+        g["A_mul_Bc!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable A_mul_Bc!($destmat, $sparsemat, $tdensemat)
+        g["Ac_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_B!($destmat, $tsparsemat, $densemat)
+        g["Ac_mul_Bc!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable Ac_mul_Bc!($destmat, $tsparsemat, $tdensemat)
+    end
 end
 
 for b in values(g)


### PR DESCRIPTION
Sort some warnings related to the `A[ct]_(mul|ldiv|rdiv)_B[ct][!]` deprecation. Ref. https://github.com/JuliaCI/BaseBenchmarks.jl/issues/158#issuecomment-357084917. Best!