### PR TITLE
Fix some 0.7 deprecations

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -192,11 +192,11 @@ end
 g = addgroup!(SUITE, "growth", ["push!", "append!", "prepend!"])
 
 for s in (8, 256, 2048)
-    v = samerand(s)
-    g["push_single!", s]   = @benchmarkable push!(x, samerand())       setup=(x = copy($v))
-    g["push_multiple!", s] = @benchmarkable perf_push_multiple!(x, $v) setup=(x = copy($v))
-    g["append!", s]        = @benchmarkable append!(x, $v)             setup=(x = copy($v))
-    g["prerend!", s]       = @benchmarkable prepend!(x, $v)            setup=(x = copy($v))
+    vs = samerand(s)
+    g["push_single!", s]   = @benchmarkable push!(x, samerand())        setup=(x = copy($vs))
+    g["push_multiple!", s] = @benchmarkable perf_push_multiple!(x, $vs) setup=(x = copy($vs))
+    g["append!", s]        = @benchmarkable append!(x, $vs)             setup=(x = copy($vs))
+    g["prerend!", s]       = @benchmarkable prepend!(x, $vs)            setup=(x = copy($vs))
 end
 
 ##########################

--- a/src/array/generate_kernel.jl
+++ b/src/array/generate_kernel.jl
@@ -279,7 +279,7 @@ function indentString(indent::Integer, str::String)
   indent_str = " "^indent
   newline_indent = "\n"*indent_str
   str = indent_str*str
-  str = replace(str, "\n", newline_indent)
+  str = replace(str, "\n" => newline_indent)
 
   return str
 end

--- a/src/misc/MiscellaneousBenchmarks.jl
+++ b/src/misc/MiscellaneousBenchmarks.jl
@@ -104,10 +104,16 @@ function nestedexpr(n)
 end"""
 include_string(@__MODULE__, nestedexpr_str)
 
+if VERSION >= v"0.7.0-DEV.2437"
+    const _parse = Meta.parse
+else
+    const _parse = Base.parse
+end
+
 g = addgroup!(SUITE, "julia")
-g["parse", "array"] = @benchmarkable parse($("[" * "a + b, "^100 * "]"))
-g["parse", "nested"] = @benchmarkable parse($(string(nestedexpr(100))))
-g["parse", "function"] = @benchmarkable parse($nestedexpr_str)
+g["parse", "array"] = @benchmarkable _parse($("[" * "a + b, "^100 * "]"))
+g["parse", "nested"] = @benchmarkable _parse($(string(nestedexpr(100))))
+g["parse", "function"] = @benchmarkable _parse($nestedexpr_str)
 g["macroexpand", "evalpoly"] = @benchmarkable macroexpand(@__MODULE__, $(Expr(:macrocall, Symbol("@evalpoly"), 1:10...)))
 
 ###########################################################################

--- a/src/problem/JSONParse.jl
+++ b/src/problem/JSONParse.jl
@@ -1,6 +1,6 @@
 module JSONParse
 
-if VERSION >= v"0.7.0-DEV.2915"
+if v"0.7.0-DEV.2915" <= VERSION < v"0.7.0-DEV.3393"
     using Unicode
 end
 

--- a/src/problem/SpellCheck.jl
+++ b/src/problem/SpellCheck.jl
@@ -3,7 +3,7 @@ module SpellCheck
 using ..ProblemBenchmarks: PROBLEM_DATA_DIR
 using Compat
 
-if VERSION >= v"0.7.0-DEV.2915"
+if v"0.7.0-DEV.2915" <= VERSION < v"0.7.0-DEV.3393"
     using Unicode
 end
 if VERSION >= v"0.7.0-DEV.3052"

--- a/src/shootout/ShootoutBenchmarks.jl
+++ b/src/shootout/ShootoutBenchmarks.jl
@@ -12,7 +12,7 @@ using .RandUtils
 using BenchmarkTools
 using Compat
 
-if VERSION >= v"0.7.0-DEV.2915"
+if v"0.7.0-DEV.2915" <= VERSION < v"0.7.0-DEV.3393"
     using Unicode
 end
 if VERSION >= v"0.7.0-DEV.3052"

--- a/src/shootout/regex_dna.jl
+++ b/src/shootout/regex_dna.jl
@@ -35,7 +35,7 @@ function perf_regex_dna()
     seq = read(infile, String)
     l1 = length(seq)
 
-    seq = replace(seq, r">.*\n|\n", "")
+    seq = replace(seq, r">.*\n|\n" => "")
     l2 = length(seq)
 
     for v in variants
@@ -47,7 +47,7 @@ function perf_regex_dna()
     end
 
     for (u, v) in subs
-        seq = replace(seq, u, v)
+        seq = replace(seq, u => v)
     end
 
 #    println()

--- a/src/string/StringBenchmarks.jl
+++ b/src/string/StringBenchmarks.jl
@@ -14,7 +14,7 @@ const SUITE = BenchmarkGroup()
 
 str = join(samerand('a':'d', 10^4))
 
-SUITE["replace"] = @benchmarkable replace($str, "a", "b")
+SUITE["replace"] = @benchmarkable replace($str, "a" => "b")
 SUITE["join"] = @benchmarkable join($str, $str) time_tolerance=0.40
 
 str = "Gf6FPPWevqer3di13haDSzrRrSiThqmV3k02dALLu7OHdYRR0dfrKf4iCMcDvgZBawx"


### PR DESCRIPTION
This tackles `replace` without `Pair`s, `parse(::String)`, and another instance of global variable overwriting. Ref #158.