### PR TITLE
Add benchmarks for map and broadcast with Union{T, Missing} arrays

### DIFF
--- a/src/union/UnionBenchmarks.jl
+++ b/src/union/UnionBenchmarks.jl
@@ -8,9 +8,9 @@ using Compat
 
 const SUITE = BenchmarkGroup()
 
-########################
+###########################
 # array Union{T, Nothing} #
-########################
+###########################
 
 g = addgroup!(SUITE, "array")
 
@@ -18,6 +18,14 @@ const VEC_LENGTH = 1000
 
 _zero(::Type{T}) where {T} = zero(T)
 _zero(::Type{Union{T, Nothing}}) where {T} = zero(T)
+
+_abs(x) = abs(x)
+_abs(::Nothing) = nothing
+
+_mul(x, y) = x * y
+_mul(::Nothing, ::Any) = nothing
+_mul(::Any, ::Nothing) = nothing
+_mul(::Nothing, ::Nothing) = nothing
 
 function perf_sum(X::AbstractArray{T}) where T
     s = _zero(T) + _zero(T)
@@ -43,6 +51,22 @@ function perf_countequals(X::AbstractArray, Y::AbstractArray)
     n
 end
 
+function perf_simplecopy(X::AbstractArray)
+    ret = similar(X)
+    @inbounds for i in eachindex(X)
+        ret[i] = X[i]
+    end
+    ret
+end
+
+function perf_binaryop(op::Function, X::AbstractArray, Y::AbstractArray)
+    ret = similar(X, Union{Nothing, typeof(op(_zero(eltype(X)), _zero(eltype(Y))))})
+    @inbounds for i in eachindex(X, Y)
+        ret[i] = op(X[i], Y[i])
+    end
+    ret
+end
+
 for T in (Bool, Int8, Int64, Float32, Float64, BigInt, BigFloat, Complex{Float64})
     if T == BigInt
         S = Int128
@@ -60,14 +84,35 @@ for T in (Bool, Int8, Int64, Float32, Float64, BigInt, BigFloat, Complex{Float64
     X2[samerand(VEC_LENGTH) .> .9] = nothing
     Y2[samerand(VEC_LENGTH) .> .9] = nothing
 
-    for A in (X, X2)
-        g["perf_sum", string(typeof(A))] = @benchmarkable perf_sum($A)
-        g["perf_countnothing", string(typeof(A))] = @benchmarkable perf_countnothing($A)
+    for (M, A) in ((false, X), (true, X2))
+        g["perf_sum", T, M] = @benchmarkable perf_sum($A)
+        g["perf_countnothing", T, M] = @benchmarkable perf_countnothing($A)
+
+        g["perf_simplecopy", T, M] =
+            @benchmarkable perf_simplecopy($A)
+        g["map", identity, T, M] =
+            @benchmarkable map(identity, $A)
+        g["broadcast", identity, T, M] =
+            @benchmarkable broadcast(identity, $A)
+
+        g["map", abs, T, M] =
+            @benchmarkable map(_abs, $A)
+        g["broadcast", abs, T, M] =
+            @benchmarkable broadcast(_abs, $A)
     end
 
-    for (A, B) in ((X, Y), (X2, Y2), (X, Y2))
-        g["perf_countequals", string(eltype(A), eltype(B))] =
+    for (M, A, B) in (((false, false), X, Y),
+                      ((true, true), X2, Y2),
+                      ((false, true), X, Y2))
+        g["perf_countequals", string(T)] =
             @benchmarkable perf_countequals($A, $B)
+
+        g["perf_binaryop", *, T, M] =
+            @benchmarkable perf_binaryop(_mul, $A, $B)
+        g["map", *, T, M] =
+            @benchmarkable map(_mul, $A, $B)
+        g["broadcast", *, T, M] =
+            @benchmarkable broadcast(_mul, $A, $B)
     end
 end
 


### PR DESCRIPTION
Add benchmarks comparing a simple loop with `map` and `broadcast`. Use `missing` instead of `nothing` since it propagates with standard operations, which allows testing more cases.

These are the benchmarks associated with https://github.com/JuliaLang/julia/pull/25828.