### PR TITLE
Remove deprecations (and coming deprecations)

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -47,7 +47,7 @@ include("sumindex.jl")
 A3d = samerand(11,11,11)
 S3d = view(A3d, 1:10, 1:10, 1:10)
 arrays = (makearrays(Int32, σ, σ)..., makearrays(Float32, σ, σ)..., trues(σ, σ), A3d, S3d)
-ranges = (1:10^5, 10^5:-1:1, 1.0:1e5, linspace(1,2,10^4))
+ranges = (1:10^5, 10^5:-1:1, 1.0:1e5, range(1,stop=2,length=10^4))
 arrays_iter = map(x -> (x, string(typeof(x))), arrays)
 ranges_iter = map(x -> (x, repr(x)), ranges)
 g = addgroup!(SUITE, "index", ["sum", "simd"])
@@ -211,7 +211,7 @@ perf_compr_collect(X) = [x for x in X]
 perf_compr_iter(X) = [sin(x) + x^2 - 3 for x in X]
 perf_compr_index(X) = [sin(X[i]) + (X[i])^2 - 3 for i in eachindex(X)]
 
-ls = linspace(0,1,10^7)
+ls = range(0,stop=1,length=10^7)
 rg = 0.0:(10.0^(-7)):1.0
 arr = collect(ls)
 
@@ -243,8 +243,8 @@ function perf_true_load!(result)
     return result
 end
 
-n, range = 10^6, -3:3
-a, b = samerand(range, n), samerand(range)
+n, vals = 10^6, -3:3
+a, b = samerand(vals, n), samerand(vals)
 
 boolarr = Vector{Bool}(uninitialized, n)
 if VERSION >= v"0.7.0-DEV.2687"

--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -47,7 +47,7 @@ include("sumindex.jl")
 A3d = samerand(11,11,11)
 S3d = view(A3d, 1:10, 1:10, 1:10)
 arrays = (makearrays(Int32, σ, σ)..., makearrays(Float32, σ, σ)..., trues(σ, σ), A3d, S3d)
-ranges = (1:10^5, 10^5:-1:1, 1.0:1e5, range(1,stop=2,length=10^4))
+ranges = (1:10^5, 10^5:-1:1, 1.0:1e5, linspace(1,2,10^4))
 arrays_iter = map(x -> (x, string(typeof(x))), arrays)
 ranges_iter = map(x -> (x, repr(x)), ranges)
 g = addgroup!(SUITE, "index", ["sum", "simd"])
@@ -211,7 +211,7 @@ perf_compr_collect(X) = [x for x in X]
 perf_compr_iter(X) = [sin(x) + x^2 - 3 for x in X]
 perf_compr_index(X) = [sin(X[i]) + (X[i])^2 - 3 for i in eachindex(X)]
 
-ls = range(0,stop=1,length=10^7)
+ls = linspace(0,1,10^7)
 rg = 0.0:(10.0^(-7)):1.0
 arr = collect(ls)
 

--- a/src/array/subarray.jl
+++ b/src/array/subarray.jl
@@ -13,13 +13,13 @@ function perf_lucompletepivCopy!(A)
         μ, λ = _maxind(As)
         μ += k-1; λ += k-1
         rowpiv[k] = μ
-        A[[k,μ], 1:n] = A[[μ,k], 1:n]
+        A[[k,μ], 1:n] .= A[[μ,k], 1:n]
         colpiv[k] = λ
-        A[1:n, [k,λ]] = A[1:n, [λ,k]]
+        A[1:n, [k,λ]] .= A[1:n, [λ,k]]
         if A[k,k] ≠ 0
             ρ = k+1:n
-            A[ρ, k] = A[ρ, k]/A[k, k]
-            A[ρ, ρ] = A[ρ, ρ] - A[ρ, k:k] * A[k:k, ρ]
+            A[ρ, k] ./= A[k, k]
+            A[ρ, ρ] .-= A[ρ, k:k] .* A[k:k, ρ]
         end
     end
     return (A, rowpiv, colpiv)
@@ -34,13 +34,13 @@ function perf_lucompletepivSub!(A)
         μ, λ = _maxind(As)
         μ += k-1; λ += k-1
         rowpiv[k] = μ
-        A[[k,μ], 1:n] = view(A, [μ,k], 1:n)
+        A[[k,μ], 1:n] .= view(A, [μ,k], 1:n)
         colpiv[k] = λ
-        A[1:n, [k,λ]] = view(A, 1:n, [λ,k])
+        A[1:n, [k,λ]] .= view(A, 1:n, [λ,k])
         if A[k,k] ≠ 0
             ρ = k+1:n
-            A[ρ, k] = view(A, ρ, k)/A[k, k]
-            A[ρ, ρ] = view(A, ρ, ρ) - view(A, ρ, k:k) * view(A, k:k, ρ)
+            A[ρ, k] ./= A[k, k]
+            A[ρ, ρ] .-= view(A, ρ, k:k) .* view(A, k:k, ρ)
         end
     end
     return (A, rowpiv, colpiv)

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -287,7 +287,7 @@ end
 function makearrays(::Type{T}, r::Integer, c::Integer) where T
     A = samerand(T, r, c)
     B = similar(A, r+1, c+1)
-    B[1:r, 1:c] = A
+    B[1:r, 1:c] .= A
     AS = ArrayLS(B)
     ASS = ArrayLSLS(B)
     AF = ArrayLF(A)

--- a/src/misc/MiscellaneousBenchmarks.jl
+++ b/src/misc/MiscellaneousBenchmarks.jl
@@ -84,7 +84,7 @@ function perf_parse(result::AbstractVector{T}, strings::AbstractVector) where T
 end
 
 g = addgroup!(SUITE, "parse", ["DateTime"])
-datestr = map(string,range(DateTime("2016-02-19T12:34:56"),step=Dates.Millisecond(123),length=200))
+datestr = map(string,range(DateTime("2016-02-19T12:34:56"),Dates.Millisecond(123),200))
 g["DateTime"] = @benchmarkable perf_parse($(similar(datestr, DateTime)), $datestr)
 g["Int"] = @benchmarkable perf_parse($(Vector{Int}(uninitialized, 1000)), $(map(string, 1:1000)))
 g["Float64"] = @benchmarkable perf_parse($(Vector{Float64}(uninitialized, 1000)), $(map(string, 1:1000)))

--- a/src/misc/MiscellaneousBenchmarks.jl
+++ b/src/misc/MiscellaneousBenchmarks.jl
@@ -84,7 +84,7 @@ function perf_parse(result::AbstractVector{T}, strings::AbstractVector) where T
 end
 
 g = addgroup!(SUITE, "parse", ["DateTime"])
-datestr = map(string,range(DateTime("2016-02-19T12:34:56"),Dates.Millisecond(123),200))
+datestr = map(string,range(DateTime("2016-02-19T12:34:56"),step=Dates.Millisecond(123),length=200))
 g["DateTime"] = @benchmarkable perf_parse($(similar(datestr, DateTime)), $datestr)
 g["Int"] = @benchmarkable perf_parse($(Vector{Int}(uninitialized, 1000)), $(map(string, 1:1000)))
 g["Float64"] = @benchmarkable perf_parse($(Vector{Float64}(uninitialized, 1000)), $(map(string, 1:1000)))

--- a/src/problem/GoGame.jl
+++ b/src/problem/GoGame.jl
@@ -351,7 +351,7 @@ function generate_move(board::Board, color::Int)
             # Further require the move not to be suicide for the opponent...
             if !suicide(board, ai, aj, other_color(color))
                 num_moves += 1
-                moves[:,num_moves] = [ai, aj]
+                moves[:,num_moves] .= (ai, aj)
             else
                 # ...however, if the move captures at least one stone,
                 # consider it anyway.
@@ -359,7 +359,7 @@ function generate_move(board::Board, color::Int)
                     (bi, bj) = neighbor(ai, aj, k)
                     if on_board(board, bi, bj) && board[bi, bj] == other_color(color)
                         num_moves += 1
-                        moves[:,num_moves] = [ai, aj]
+                        moves[:,num_moves] .= (ai, aj)
                         break
                     end
                 end

--- a/src/problem/Laplacian.jl
+++ b/src/problem/Laplacian.jl
@@ -33,7 +33,7 @@ function ddx_spdiags(m)
     # Append new d[k]-th diagonal to compact form
     for k = 1:p
         i = max(1,1-d[k]):min(m,n-d[k])
-        a[(len[k]+1):len[k+1],:] = [i i.+d[k] B[i.+(m>=n)*d[k],k]]
+        a[(len[k]+1):len[k+1],:] .= [i i.+d[k] B[i.+(m>=n)*d[k],k]]
     end
 
     return sparse(a[:,1], a[:,2], a[:,3], m, n)


### PR DESCRIPTION
When a deprecation appears in the hot loop of a tuned benchmark, BaseBenchmarks basically becomes non-terminating.  So this PR anticipates some of the coming changes in JuliaLang/julia#24368.  I have also taken the opportunity to fix the few other deprecations I ran into -- none of those were in hot loops.

Note that I have significantly changed some of these algorithms in order to better take advantage of dot-fusion.  I think that is in the spirit of those specific benchmarks, but if desired I can happily revert that back to the most-minimal change required to avoid the deprecation.