### PR TITLE
Remove dependency on StatsBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
 BenchmarkTools 0.2.1
 Compat 0.60.0
-StatsBase

--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -6,7 +6,6 @@ using .RandUtils
 using BenchmarkTools
 using Compat
 using Compat.LinearAlgebra
-using StatsBase
 
 const SUITE = BenchmarkGroup()
 
@@ -22,8 +21,11 @@ norminf(x) = norm(x, Inf)
 perf_reduce(x) = reduce((x,y) -> x + 2y, real(zero(eltype(x))), x)
 perf_mapreduce(x) = mapreduce(x -> real(x)+imag(x), (x,y) -> x + 2y, real(zero(eltype(x))), x)
 for a in (afloat, aint)
-    for fun in (sum, norm, norm1, norminf, mean, var, perf_reduce, perf_mapreduce)
+    for fun in (sum, norm, norm1, norminf, mean, perf_reduce, perf_mapreduce)
         g[string(fun), string(eltype(a))] = @benchmarkable $fun($a)
+    end
+    @static if VERSION < v"0.7.0-DEV.5238"
+        g["var", string(eltype(a))] = @benchmarkable var($a)
     end
     g["sumabs2", string(eltype(a))] = @benchmarkable sum(abs2, $a)
     g["sumabs", string(eltype(a))] = @benchmarkable sum(abs, $a)

--- a/src/micro/MicroBenchmarks.jl
+++ b/src/micro/MicroBenchmarks.jl
@@ -5,7 +5,6 @@ using Compat
 if VERSION >= v"0.7.0-DEV.3449"
     using LinearAlgebra
 end
-using StatsBase
 
 # This module contains the Julia microbenchmarks shown in the language
 # comparison table at http://julialang.org/.

--- a/src/micro/methods.jl
+++ b/src/micro/methods.jl
@@ -92,6 +92,17 @@ else
     _at_mul_b(A, B) = At_mul_B(A, B)
 end
 
+if VERSION >= v"0.7.0-DEV.5238"
+    # std in StatsBase instead of in Base
+    function stdmean(x)
+        n = length(x)
+        m = mean(x)
+        sqrt(sum(xi->abs2(xi - m), x) / (n - 1)) / m
+    end
+else
+    stdmean(x) = std(x) / mean(x)
+end
+
 function perf_micro_randmatstat(t)
     n = 5
     v = zeros(t)
@@ -106,7 +117,7 @@ function perf_micro_randmatstat(t)
         v[i] = trace(_at_mul_b(P,P)^4)
         w[i] = trace(_at_mul_b(Q,Q)^4)
     end
-    return (std(v)/mean(v), std(w)/mean(w))
+    return (stdmean(v), stdmean(w))
 end
 
 ##############


### PR DESCRIPTION
Instead, condition the `var` benchmark on it being in Base, and rework the use of `std` to compute the standard deviation manually.

This was my bad, we shouldn't have external dependencies in BaseBenchmarks other than Compat and BenchmarkTools.