### PR TITLE
change the objects in group to be stored in a Vector instead of Array

### DIFF
--- a/src/problem/Raytracer.jl
+++ b/src/problem/Raytracer.jl
@@ -76,7 +76,7 @@ end
 
 struct Group <: Scene
     bound::Sphere
-    objs::Array{Scene}
+    objs::Vector{Scene}
 end
 
 Group(b::Sphere) = Group(b, Scene[])


### PR DESCRIPTION
Using `Array` is overly pessimistic.