### PR TITLE
workaround issue #15276

### DIFF
--- a/src/shootout/revcomp.jl
+++ b/src/shootout/revcomp.jl
@@ -52,7 +52,9 @@ function perf_revcomp()
     #            write(line)
             else
                 l = length(line)-1
-                append!(buff, [UInt8(revcompdata[Char(line[i])]) for i=1:l])
+                let line = line # Workaround for julia#15276
+                    append!(buff, [UInt8(revcompdata[Char(line[i])]) for i=1:l])
+                end
             end
         end
     end


### PR DESCRIPTION
the current implementation hits https://github.com/JuliaLang/julia/issues/15276 so the benchmark doesn't measure what is intended.