### PR TITLE
Add sort benchmark for Union{T, Missing}

### DIFF
--- a/src/union/UnionBenchmarks.jl
+++ b/src/union/UnionBenchmarks.jl
@@ -124,6 +124,10 @@ for T in (Bool, Int8, Int64, Float32, Float64, BigInt, BigFloat, Complex{Float64
 
             g["skipmissing", sum, T, M] =
                 @benchmarkable sum(skipmissing($A2))
+
+            if hasmethod(isless, Tuple{T, T})
+                g["sort", T, M] = @benchmarkable sort($A2)
+            end
         end
     end
 end


### PR DESCRIPTION
Only run on 0.7 since Base.Sort.Defalg treats missing differently from nothing, and missing does not exist on 0.6.