### PR TITLE
disable UTF check when creating input data

### DIFF
--- a/src/problem/SpellCheck.jl
+++ b/src/problem/SpellCheck.jl
@@ -24,6 +24,7 @@ const ALPHABET = "abcdefghijklmnopqrstuvwxyz"
 words(text) = eachmatch(r"[a-z]+", lowercase(text))
 
 function train(features)
+    features.regex.match_options = Base.PCRE.NO_UTF_CHECK
     model = Dict{AbstractString, Int}()
     for f in features
         model[f.match] = 2


### PR DESCRIPTION
Should fix loading the problem dataset taking forever.

Note that this doesn't change any benchmark, just makes creating the input data set faster.