### PR TITLE
Adapt to new `init` keyword for `reduce` family of functions

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -18,8 +18,13 @@ acomplex = samerand(Complex{Float64}, 10^3)
 g = addgroup!(SUITE, "reductions", ["sum", "array", "reduce"])
 norm1(x) = norm(x, 1)
 norminf(x) = norm(x, Inf)
-perf_reduce(x) = reduce((x,y) -> x + 2y, real(zero(eltype(x))), x)
-perf_mapreduce(x) = mapreduce(x -> real(x)+imag(x), (x,y) -> x + 2y, real(zero(eltype(x))), x)
+if VERSION < v"0.7.0-beta-81"
+    perf_reduce(x) = reduce((x,y) -> x + 2y, real(zero(eltype(x))), x)
+    perf_mapreduce(x) = mapreduce(x -> real(x)+imag(x), (x,y) -> x + 2y, real(zero(eltype(x))), x)
+else
+    perf_reduce(x) = reduce((x,y) -> x + 2y, x; init=real(zero(eltype(x))))
+    perf_mapreduce(x) = mapreduce(x -> real(x)+imag(x), (x,y) -> x + 2y, x; init=real(zero(eltype(x))))
+end
 for a in (afloat, aint)
     for fun in (sum, norm, norm1, norminf, mean, perf_reduce, perf_mapreduce)
         g[string(fun), string(eltype(a))] = @benchmarkable $fun($a)

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -201,11 +201,20 @@ function setup_mapr_access(A)
     B = Vector{typeof(zz)}(undef, n)
     B, zz, n
 end
-function perf_mapr_access(A, B, zz, n) #20517
-    @inbounds for j in 1:n
-        B[j] = mapreduce(k -> A[j,k]*A[k,j], +, zz, 1:j)
+if VERSION < v"0.7.0-beta-81"
+    function perf_mapr_access(A, B, zz, n) #20517
+        @inbounds for j in 1:n
+            B[j] = mapreduce(k -> A[j,k]*A[k,j], +, zz, 1:j)
+        end
+        B
     end
-    B
+else
+    function perf_mapr_access(A, B, zz, n) #20517
+        @inbounds for j in 1:n
+            B[j] = mapreduce(k -> A[j,k]*A[k,j], +, 1:j; init=zz)
+        end
+        B
+    end
 end
 
 ##########################


### PR DESCRIPTION
Should fix deprecations that caused degradations in https://github.com/JuliaLang/julia/pull/27711