### PR TITLE
Use bigger vector for Union benchmarks

### DIFF
--- a/src/union/UnionBenchmarks.jl
+++ b/src/union/UnionBenchmarks.jl
@@ -14,7 +14,7 @@ const SUITE = BenchmarkGroup()
 
 g = addgroup!(SUITE, "array")
 
-const VEC_LENGTH = 1000
+const VEC_LENGTH = 10000
 
 _zero(::Type{T}) where {T} = zero(T)
 _zero(::Type{Union{T, Nothing}}) where {T} = zero(T)


### PR DESCRIPTION
This should limit spurious results for sum. It also reflects better typical use cases (data frame columns with missing values in large datasets).