### PR TITLE
Improve Union benchmarks

### DIFF
--- a/src/union/UnionBenchmarks.jl
+++ b/src/union/UnionBenchmarks.jl
@@ -153,17 +153,17 @@ for T in (Bool, Int8, Int64, Float32, Float64, BigInt, BigFloat, Complex{Float64
     end
 
     if VERSION >= v"0.7.0-DEV.2971"
-        for (M, A) in ((false, X), (true, X2))
-            A2 = [x === nothing ? missing : x for x in A]
+        for (M, A) in ((false, Vector{T}(X)),
+                       (false, X),
+                       (true, replace(X2, nothing=>missing)))
+            g["skipmissing", collect, eltype(A), M] =
+                @benchmarkable collect(skipmissing($A))
 
-            g["skipmissing", collect, T, M] =
-                @benchmarkable collect(skipmissing($A2))
-
-            g["skipmissing", sum, T, M] =
-                @benchmarkable sum(skipmissing($A2))
+            g["skipmissing", sum, eltype(A), M] =
+                @benchmarkable sum(skipmissing($A))
 
             if hasmethod(isless, Tuple{T, T})
-                g["sort", T, M] = @benchmarkable sort($A2)
+                g["sort", eltype(A), M] = @benchmarkable sort($A)
             end
         end
     end


### PR DESCRIPTION
Cover both `T`, `Union{T,Missing}` without missing values and `Union{T,Missing}` with missing values.