### PR TITLE
Fix readstring benchmark, add readfloat64.

### DIFF
--- a/src/io/IOBenchmarks.jl
+++ b/src/io/IOBenchmarks.jl
@@ -19,21 +19,20 @@ const SUITE = BenchmarkGroup()
 # read (#12364) #
 #################
 
-function perf_read!(io)
+function perf_read!(io, ::Type{T}) where T
     seekstart(io)
-    x = 0
+    x = zero(T)
     while !(eof(io))
-        x += read(io, UInt8)
+        x += read(io, T)
     end
     return x
 end
 
 g = addgroup!(SUITE, "read", ["buffer", "stream", "string"])
 
-testbuf = IOBuffer(randstring(RandUtils.SEED, 10^4))
-
-g["read"]       = @benchmarkable perf_read!($testbuf)
-g["readstring"] = @benchmarkable read($testbuf, String)
+g["read"] = @benchmarkable perf_read!(testbuf, UInt8) setup = testbuf = IOBuffer(randstring(RandUtils.SEED, 10^4))
+g["readfloat64"] = @benchmarkable perf_read!(testbuf, Float64) setup = testbuf = IOBuffer(randstring(RandUtils.SEED, 10^4))
+g["readstring"] = @benchmarkable read(testbuf, String) setup = testbuf = IOBuffer(randstring(RandUtils.SEED, 10^4))
 
 #################################
 # serialization (#18633, #7893) #


### PR DESCRIPTION
`g["read"]` and `g["readstring"]` were using the same `testbuf`, which would be at end-of-file after either one was run.

The real reason for this PR is adding the `Float64` benchmark though; I just found the `readstring` issue in the process. I'm quite unhappy with the fact that reading (and writing, but that's for a later time) primitive types allocates. I thought that maybe this would be resolved in 0.7 (elimination of the allocation of the `Ref` [here](https://github.com/JuliaLang/julia/blob/master/base/io.jl#L598)), but I guess that's being explicitly prevented by the `@noinline` [here](https://github.com/JuliaLang/julia/blob/a2149f890fb9ba8846e2731cd193774597bd4916/base/io.jl#L592).

BufferedStreams.jl has [this implementation](https://github.com/BioJulia/BufferedStreams.jl/blob/15accc20738f4f8348fcb307d4889277572fc7e8/src/bufferedinputstream.jl#L194-L208), which doesn't allocate. Is something like this acceptable for Base as well?

Result of running `run(g["readfloat64"])` on my machine:

```julia
BenchmarkTools.Trial: 
  memory estimate:  19.53 KiB
  allocs estimate:  1250
  --------------
  minimum time:     15.996 μs (0.00% GC)
  median time:      17.784 μs (0.00% GC)
  mean time:        21.219 μs (10.89% GC)
  maximum time:     13.179 ms (99.83% GC)
  --------------
  samples:          10000
  evals/sample:     1
```