### PR TITLE
Add Gram-Schmidt orthonormalization to test view speed

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -167,12 +167,19 @@ include("subarray.jl")
 
 n = samerand()
 
-g = addgroup!(SUITE, "subarray", ["lucompletepiv"])
+g = addgroup!(SUITE, "subarray", ["lucompletepiv", "gramschmidt"])
 
 for s in (100, 250, 500, 1000)
     m = samerand(s, s)
     g["lucompletepivCopy!", s] = @benchmarkable perf_lucompletepivCopy!(fill!($m, $n))
     g["lucompletepivSub!", s]  = @benchmarkable perf_lucompletepivSub!(fill!($m, $n))
+end
+
+# Gram-Schmidt orthonormalization, using views to operate on matrix slices.
+
+for s in (100, 250, 500, 1000)
+    m = samerand(s, s)
+    g["gramschmidt!", s] = @benchmarkable perf_gramschmidt!(fill!($m, $n))
 end
 
 #################

--- a/src/array/subarray.jl
+++ b/src/array/subarray.jl
@@ -50,7 +50,7 @@ function perf_gramschmidt!(U)
     m = size(U, 2)
     @inbounds for k = 1:m
         uk = view(U,:,k)
-        @inbounds for j = 1:k-1
+        for j = 1:k-1
             uj = view(U,:,j)
             uk .-= (uj ⋅ uk) .* uj
         end

--- a/src/array/subarray.jl
+++ b/src/array/subarray.jl
@@ -45,3 +45,15 @@ function perf_lucompletepivSub!(A)
     end
     return (A, rowpiv, colpiv)
 end
+
+function perf_gramschmidt!(U)
+    m = size(U, 2)
+    @inbounds for k = 1:m
+        uk = view(U,:,k)
+        @inbounds for j = 1:k-1
+            uj = view(U,:,j)
+            uk .-= (uj ⋅ uk) .* uj
+        end
+        uk ./= norm(uk)
+    end
+end


### PR DESCRIPTION
As suggested in https://discourse.julialang.org/t/avoiding-memory-allocation-for-vector-operations/12447/2?u=jdrugo
adding Gram-Schmidt orthonormalization that uses views for matrix slices
to test speed/allocation of these slices.