### PR TITLE
Add benchmarks for collecting zip iterators

### DIFF
--- a/src/misc/MiscellaneousBenchmarks.jl
+++ b/src/misc/MiscellaneousBenchmarks.jl
@@ -296,4 +296,13 @@ for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
     g[string(T)] = @benchmarkable perf_copy_23042($(Foo_23042(a)), $(Foo_23042(b)))
 end
 
+###############################################
+# zip iterator
+
+g = addgroup!(SUITE, "iterators", ["zip"])
+for N in (1,1000), M in 1:4
+    X = zip(Iterators.repeated(1:N, M)...)
+    g["zip($(join(fill("1:$N", M), ", ")))"] = @benchmarkable collect($X)
+end
+
 end


### PR DESCRIPTION
Adds the benchmarks I've been running repeatedly in https://github.com/JuliaLang/julia/pull/29238.