### PR TITLE
Fix Array growth benchmark: interpolate `samerand()` instead of calculating inside benchmark loop

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -219,7 +219,7 @@ g = addgroup!(SUITE, "growth", ["push!", "append!", "prepend!"])
 
 for s in (8, 256, 2048)
     vs = samerand(s)
-    g["push_single!", s]   = @benchmarkable push!(x, samerand())        setup=(x = copy($vs))
+    g["push_single!", s]   = @benchmarkable push!(x, $(samerand()))     setup=(x = copy($vs))
     g["push_multiple!", s] = @benchmarkable perf_push_multiple!(x, $vs) setup=(x = copy($vs))
     g["append!", s]        = @benchmarkable append!(x, $vs)             setup=(x = copy($vs))
     g["prerend!", s]       = @benchmarkable prepend!(x, $vs)            setup=(x = copy($vs))


### PR DESCRIPTION
Speeds up the benchmark run by removing unrelated work from benchmark loop. 

Before this commit, it was incorrectly including the `samerand()` calculation as part of the array growth benchmark.

I don't actually know the right way to list the performance improvements, but I did it like this:
```julia
julia> improvements = regressions(judge(minimum(master), minimum(pr))); # Reversed master & pr to print improvements

julia> pairs = leaves(improvements) # an array of (ID, `TrialJudgement`) pairs
3-element Array{Any,1}:
 (Any["(\"push_single!\", 2048)"], TrialJudgement(+738.94% => regression))
 (Any["(\"push_single!\", 256)"], TrialJudgement(+2911.24% => regression))
 (Any["(\"push_single!\", 8)"], TrialJudgement(+7394.20% => regression))
```