### PR TITLE
add test for 3- and 5-arg mul! with 2x2 and 3x3 matrices product

### DIFF
--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -115,6 +115,17 @@ for s in SIZES
 
 end
 
+# Issue #34013: mul! for 2x2 or 3x3 matrices
+for s in (2, 3)
+    A = randmat(s)
+    B = randmat(s)
+    C = randmat(s)
+    (α, β) = rand(2)
+    g["3-arg mul!", s] = @benchmarkable LinearAlgebra.mul!($C, $A, $B)
+    g["5-arg mul!", s] = @benchmarkable LinearAlgebra.mul!($C, $A, $B, $α, $β)
+end
+
+
 for b in values(g)
     b.params.time_tolerance = 0.45
     b.params.samples = 100

--- a/src/linalg/LinAlgBenchmarks.jl
+++ b/src/linalg/LinAlgBenchmarks.jl
@@ -18,7 +18,7 @@ typename(::Type{T}) where {T} = string(isa(T,DataType) ? T.name : Base.unwrap_un
 typename(::Type{M}) where {M<:Matrix} = "Matrix"
 typename(::Type{V}) where {V<:Vector} = "Vector"
 
-const UPLO = :U 
+const UPLO = :U
 
 linalgmat(::Type{Matrix}, s) = randmat(s)
 linalgmat(::Type{Diagonal}, s) = Diagonal(randvec(s))
@@ -120,9 +120,12 @@ for s in (2, 3)
     A = randmat(s)
     B = randmat(s)
     C = randmat(s)
-    (α, β) = rand(2)
     g["3-arg mul!", s] = @benchmarkable LinearAlgebra.mul!($C, $A, $B)
-    g["5-arg mul!", s] = @benchmarkable LinearAlgebra.mul!($C, $A, $B, $α, $β)
+    
+    if VERSION >= v"1.3"
+        (α, β) = rand(2)
+        g["5-arg mul!", s] = @benchmarkable LinearAlgebra.mul!($C, $A, $B, $α, $β)
+    end
 end
 
 


### PR DESCRIPTION
For tracking e.g. https://github.com/JuliaLang/julia/issues/34013: the matrix product of 2x2 and 3x3 matrices are done in julia rather than dispatched to BLAS for performance.