### PR TITLE
Add benchmarks for `==(::AbstractString, ::AbstractString)`

### DIFF
--- a/src/string/StringBenchmarks.jl
+++ b/src/string/StringBenchmarks.jl
@@ -57,4 +57,18 @@ g["repeat str len 16"] = @benchmarkable repeat("repeatmerepeatme", 500)
 g["repeat char 1"] = @benchmarkable repeat(' ', 500)
 g["repeat char 2"] = @benchmarkable repeat('α', 500)
 
+###################################################
+# ==(::AbstractString, ::AbstractString) (#37192) #
+###################################################
+
+str = "A" ^ 1000
+
+g = addgroup!(SUITE, "==(::AbstractString, ::AbstractString)")
+
+g["identical"] = @benchmarkable invoke(==, Tuple{AbstractString, AbstractString}, $"ABC", $"ABC")
+g["different length"] = @benchmarkable $(SubString("ABC")) == $"ABCD"
+g["equal"] = @benchmarkable $(SubString("ABC")) == $"ABC"
+g["different"] = @benchmarkable $(SubString("ABC")) == $"DEF"
+g["long equal"] = @benchmarkable $(SubString(str)) == $str
+
 end # module

--- a/src/string/StringBenchmarks.jl
+++ b/src/string/StringBenchmarks.jl
@@ -57,6 +57,17 @@ g["repeat str len 16"] = @benchmarkable repeat("repeatmerepeatme", 500)
 g["repeat char 1"] = @benchmarkable repeat(' ', 500)
 g["repeat char 2"] = @benchmarkable repeat('α', 500)
 
+######################################
+# ==(::SubString, ::String) (#35973) #
+######################################
+
+str = String('A':'Z') ^ 100
+g = addgroup!(SUITE, "==(::SubString, ::String)")
+
+g["equal"] = @benchmarkable $(SubString(str)) == $str
+g["different length"] = @benchmarkable $(SubString(str)) == $(str * 'Z')
+g["different"] = @benchmarkable $(SubString(str)) == $(reverse(str))
+
 ###################################################
 # ==(::AbstractString, ::AbstractString) (#37467) #
 ###################################################

--- a/src/string/StringBenchmarks.jl
+++ b/src/string/StringBenchmarks.jl
@@ -58,17 +58,15 @@ g["repeat char 1"] = @benchmarkable repeat(' ', 500)
 g["repeat char 2"] = @benchmarkable repeat('α', 500)
 
 ###################################################
-# ==(::AbstractString, ::AbstractString) (#37192) #
+# ==(::AbstractString, ::AbstractString) (#37467) #
 ###################################################
 
-str = "A" ^ 1000
-
+str = String('A':'Z') ^ 100
 g = addgroup!(SUITE, "==(::AbstractString, ::AbstractString)")
 
-g["identical"] = @benchmarkable invoke(==, Tuple{AbstractString, AbstractString}, $"ABC", $"ABC")
-g["different length"] = @benchmarkable $(SubString("ABC")) == $"ABCD"
-g["equal"] = @benchmarkable $(SubString("ABC")) == $"ABC"
-g["different"] = @benchmarkable $(SubString("ABC")) == $"DEF"
-g["long equal"] = @benchmarkable $(SubString(str)) == $str
+g["identical"] = @benchmarkable invoke(==, Tuple{AbstractString, AbstractString}, $str, $str)
+g["equal"] = @benchmarkable invoke(==, Tuple{AbstractString, AbstractString}, $(SubString(str)), $str)
+g["different length"] = @benchmarkable invoke(==, Tuple{AbstractString, AbstractString}, $(SubString(str)), $(str * 'Z'))
+g["different"] = @benchmarkable invoke(==, Tuple{AbstractString, AbstractString}, $(SubString(str)), $(reverse(str)))
 
 end # module


### PR DESCRIPTION
String equality got a performance boost in https://github.com/JuliaLang/julia/pull/37192#issuecomment-687390486 and I wanted to make we don't see a regression in the future. 