### PR TITLE
Add workflow to open retuning PRs automatically

### DIFF
--- a/.github/workflows/retune.yml
+++ b/.github/workflows/retune.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - retune
+jobs:
+  PullRequest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Retune parameters',
+              head: 'retune',
+              base: 'master',
+            })


### PR DESCRIPTION
The process is like this:

- cron job on nanosoldier6 runs the retuning script, then pushes the new `params.json` to a branch called `retune`
- this workflow picks up that push and opens a PR from `retune` to `master`