### PR TITLE
add simple allocation benchmarks

### DIFF
--- a/src/BaseBenchmarks.jl
+++ b/src/BaseBenchmarks.jl
@@ -10,6 +10,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.memory_tolerance = 0.01
 const PARAMS_PATH = joinpath(dirname(@__FILE__), "..", "etc", "params.json")
 const SUITE = BenchmarkGroup()
 const MODULES = Dict("array" => :ArrayBenchmarks,
+                     "alloc" => :AllocBenchmarks,
                      "broadcast" => :BroadcastBenchmarks,
                      "collection" => :CollectionBenchmarks,
                      "dates" => :DatesBenchmarks,

--- a/src/alloc/AllocBenchmarks.jl
+++ b/src/alloc/AllocBenchmarks.jl
@@ -1,0 +1,24 @@
+module AllocBenchmarks
+
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+function perf_alloc_many_arrays()
+  a = nothing
+  for _ in 1:10000000
+      a = []
+  end
+end
+
+function perf_alloc_many_strings()
+  a = nothing
+  for i in 1:10000000
+      a = "hello $(i)"
+  end
+end
+
+SUITE["arrays"] = @benchmarkable perf_alloc_many_arrays()
+SUITE["strings"] = @benchmarkable perf_alloc_many_strings()
+
+end # module


### PR DESCRIPTION
cc @vchuravy 

A simple-as-possible benchmark to help us see the impact of https://github.com/JuliaLang/julia/pull/42768, https://github.com/JuliaLang/julia/pull/43868 etc.

Not sure if I should be doing these loops myself, or letting BenchmarkTools do them for me.

Also, I tried doing a similar thing to allocate a struct, but it seemed to be stack allocated. Any way to get it to go on the heap? Also was thinking of using `@timed` and asserting against `gc_stats.poolalloc` to make sure we're actually measuring pool allocations.