### PR TITLE
rename `["inference", "inference"]` subgroup to `["inference", "allinference"]`

### DIFF
--- a/src/inference/InferenceBenchmarks.jl
+++ b/src/inference/InferenceBenchmarks.jl
@@ -172,7 +172,7 @@ let g = addgroup!(SUITE, "optimization")
     tune_benchmarks!(g)
 end
 
-let g = addgroup!(SUITE, "inference")
+let g = addgroup!(SUITE, "allinference")
     g["sin(42)"] = @benchmarkable (@inf_call sin(42))
     g["rand(Float64)"] = @benchmarkable (@inf_call rand(Float64))
     g["println(::QuoteNode)"] = @benchmarkable (inf_call(println, (QuoteNode,)))


### PR DESCRIPTION
The nanosoldier seems to unify the subgroup names otherwise somehow like:

    ["inference", "abstract interpretation"]
    ["inference"]
    ["inference", "optimization"]

This change circumvents it and also makes the subgroup meaning more explicit:

    ["inference", "abstract interpretation"]
    ["inference", "allinference"]
    ["inference", "optimization"]