### PR TITLE
save several GB of memory on just load

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -13,21 +13,23 @@ using Statistics
 #############################################################################
 # basic array-math reduction-like functions
 
-afloat = samerand(10^3)
-aint = samerand(Int, 10^3)
-acomplex = samerand(Complex{Float64}, 10^3)
+getafloat() = samerand(10^3)
+getaint() = samerand(Int, 10^3)
+getacomplex() = samerand(Complex{Float64}, 10^3)
+
 g = addgroup!(SUITE, "reductions", ["sum", "array", "reduce"])
 norm1(x) = norm(x, 1)
 norminf(x) = norm(x, Inf)
 perf_reduce(x) = reduce((x,y) -> x + 2y, x; init=real(zero(eltype(x))))
 perf_mapreduce(x) = mapreduce(x -> real(x)+imag(x), (x,y) -> x + 2y, x; init=real(zero(eltype(x))))
-for a in (afloat, aint)
+for geta in (getafloat, getaint)
+    a = geta()
     for fun in (sum, norm, norm1, norminf, mean, perf_reduce, perf_mapreduce)
-        g[string(fun), string(eltype(a))] = @benchmarkable $fun($a)
+        g[string(fun), string(eltype(a))] = @benchmarkable $fun(a) setup=(a=$geta())
     end
-    g["sumabs2", string(eltype(a))] = @benchmarkable sum(abs2, $a)
-    g["sumabs", string(eltype(a))] = @benchmarkable sum(abs, $a)
-    g["maxabs", string(eltype(a))] = @benchmarkable maximum(abs, $a)
+    g["sumabs2", string(eltype(a))] = @benchmarkable sum(abs2, a) setup=(a=$geta())
+    g["sumabs", string(eltype(a))] = @benchmarkable sum(abs, a) setup=(a=$geta())
+    g["maxabs", string(eltype(a))] = @benchmarkable maximum(abs, a) setup=(a=$geta())
 end
 
 #############################################################################
@@ -41,43 +43,57 @@ end
 
 include("sumindex.jl")
 
-σ = 500
-A3d = samerand(11,11,11)
-S3d = view(A3d, 1:10, 1:10, 1:10)
-A3i = reinterpret(Int32, A3d)  # half-size, no fields
-arrays = (makearrays(Int32, σ, σ)..., makearrays(Float32, σ, σ)..., trues(σ, σ), A3d, S3d, A3i)
-ranges = (1:10^5, 10^5:-1:1, 1.0:1e5, range(1, stop=2, length=10^4))
-arrays_iter = map(x -> (x, string(typeof(x))), arrays)
-ranges_iter = map(x -> (x, repr(x)), ranges)
 g = addgroup!(SUITE, "index", ["sum", "simd"])
-
-for (A, str) in (arrays_iter..., ranges_iter...)
-    g["sumelt", str]             = @benchmarkable perf_sumelt($A)
-    g["sumelt_boundscheck", str] = @benchmarkable perf_sumelt_boundscheck($A)
-    g["sumeach", str]            = @benchmarkable perf_sumeach($A)
-    g["sumlinear", str]          = @benchmarkable perf_sumlinear($A)
-    g["sumcartesian", str]       = @benchmarkable perf_sumcartesian($A)
-    g["sumeach_view", str]       = @benchmarkable perf_sumeach_view($A)
-    g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view($A)
-    g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view($A)
-    if ndims(A) == 2
-        g["mapr_access", str]    = @benchmarkable perf_mapr_access($A, B, zz, n) setup = begin B, zz, n = setup_mapr_access($A) end #20517
+const σ = 500
+let nint32 = makearrays(Int32, σ, σ, 0)::Int,
+    nfloat32 = makearrays(Float32, σ, σ, 0)::Int,
+    ranges = (1:10^5, 10^5:-1:1, 1.0:1e5, range(1, stop=2, length=10^4)),
+    ntotal = 4 + nint32 + nfloat32 + length(ranges)
+    function getarray(i)
+        (i <= nint32) && return makearrays(Int32, σ, σ, i)
+        i -= nint32
+        (i <= nfloat32) && return makearrays(Float32, σ, σ, i)
+        i -= nfloat32
+        ((i -= 1) == 0) && return trues(σ, σ)
+        A3d = samerand(11,11,11)
+        ((i -= 1) == 0) && return A3d
+        ((i -= 1) == 0) && return view(A3d, 1:10, 1:10, 1:10)
+        ((i -= 1) == 0) && return reinterpret(Int32, A3d)  # half-size, no fields
+        return ranges[i]
     end
-    if ndims(A) <= 2
-        g["sumcolon", str]       = @benchmarkable perf_sumcolon($A)
-        g["sumrange", str]       = @benchmarkable perf_sumrange($A)
-        g["sumlogical", str]     = @benchmarkable perf_sumlogical($A)
-        g["sumvector", str]      = @benchmarkable perf_sumvector($A)
-        g["sumcolon_view", str]  = @benchmarkable perf_sumcolon_view($A)
-        g["sumrange_view", str]  = @benchmarkable perf_sumrange_view($A)
-        g["sumlogical_view", str]= @benchmarkable perf_sumlogical_view($A)
-        g["sumvector_view", str] = @benchmarkable perf_sumvector_view($A)
+    for i = 1:ntotal
+        A = getarray(i)
+        str = A isa AbstractRange ? repr(A) : string(typeof(A))
+        g["sumelt", str]             = @benchmarkable perf_sumelt(A) setup=(A=$getarray($i))
+        g["sumelt_boundscheck", str] = @benchmarkable perf_sumelt_boundscheck(A) setup=(A=$getarray($i))
+        g["sumeach", str]            = @benchmarkable perf_sumeach(A) setup=(A=$getarray($i))
+        g["sumlinear", str]          = @benchmarkable perf_sumlinear(A) setup=(A=$getarray($i))
+        g["sumcartesian", str]       = @benchmarkable perf_sumcartesian(A) setup=(A=$getarray($i))
+        g["sumeach_view", str]       = @benchmarkable perf_sumeach_view(A) setup=(A=$getarray($i))
+        g["sumlinear_view", str]     = @benchmarkable perf_sumlinear_view(A) setup=(A=$getarray($i))
+        g["sumcartesian_view", str]  = @benchmarkable perf_sumcartesian_view(A) setup=(A=$getarray($i))
+        if ndims(A) == 2
+            g["mapr_access", str]    = @benchmarkable perf_mapr_access(A, B, zz, n) setup = begin
+                A = $getarray($i)
+                B, zz, n = setup_mapr_access(A) #20517
+            end
+        end
+        if ndims(A) <= 2
+            g["sumcolon", str]       = @benchmarkable perf_sumcolon(A) setup=(A=$getarray($i))
+            g["sumrange", str]       = @benchmarkable perf_sumrange(A) setup=(A=$getarray($i))
+            g["sumlogical", str]     = @benchmarkable perf_sumlogical(A) setup=(A=$getarray($i))
+            g["sumvector", str]      = @benchmarkable perf_sumvector(A) setup=(A=$getarray($i))
+            g["sumcolon_view", str]  = @benchmarkable perf_sumcolon_view(A) setup=(A=$getarray($i))
+            g["sumrange_view", str]  = @benchmarkable perf_sumrange_view(A) setup=(A=$getarray($i))
+            g["sumlogical_view", str]= @benchmarkable perf_sumlogical_view(A) setup=(A=$getarray($i))
+            g["sumvector_view", str] = @benchmarkable perf_sumvector_view(A) setup=(A=$getarray($i))
+        end
     end
 end
 g["sub2ind"] = @benchmarkable perf_sub2ind((1000,1000,1000), 1:1000, 1:1000, 1:1000)
 g["ind2sub"] = @benchmarkable perf_ind2sub((100,100,10), 1:10^5)
-g["sum", "3darray"] = @benchmarkable sum($A3d)
-g["sum", "3dsubarray"] = @benchmarkable sum($S3d)
+g["sum", "3darray"] = @benchmarkable sum(A3d) setup=(A3d=samerand(11,11,11))
+g["sum", "3dsubarray"] = @benchmarkable sum(S3d) setup=(A3d=samerand(11,11,11); S3d=view(A3d, 1:10, 1:10, 1:10))
 
 for b in values(g)
     b.params.time_tolerance = 0.50
@@ -88,7 +104,7 @@ end
 #--------#
 include("generate_kernel.jl")
 
-nmax = 6  # maximum dimensionality is nmax + 1
+const nmax = 6  # maximum dimensionality is nmax + 1
 # get path to tempdir and append file name to it
 mktempdir() do dir
     fname = joinpath(dir, "hdindexing.jl")
@@ -96,18 +112,17 @@ mktempdir() do dir
     include(fname)
 end
 
-npts_dir = [10000, 80, 20, 12, 9, 6]  # number of points in each direction
-for i=1:nmax
-  dims_vec = zeros(Int, i+1)
-  fill!(dims_vec, npts_dir[i])
-  dims_vec[end] = 2  # last dimension must be 2
-  u_i = samerand(dims_vec...)
-  u_ip1 = zeros(dims_vec...)
-
+const npts_dir = [10000, 80, 20, 12, 9, 6]  # number of points in each direction
+for i = 1:nmax
   str = string(i+1, "d")
-
   # perf_hdindexing is defined in the generated source file hdindexing.jl
-  g[str] = @benchmarkable perf_hdindexing5($u_i, $u_ip1)
+  g[str] = @benchmarkable perf_hdindexing5(u_i, u_ip1) setup=begin
+      dims_vec = zeros(Int, $i+1)
+      fill!(dims_vec, npts_dir[$i])
+      dims_vec[end] = 2  # last dimension must be 2
+      u_i = samerand(dims_vec...)
+      u_ip1 = zeros(dims_vec...)
+  end
 end
 
 
@@ -118,15 +133,13 @@ end
 
 include("revloadindex.jl")
 
-v = samerand(10^6)
-n = samerand()
-
 g = addgroup!(SUITE, "reverse", ["index", "fill!"])
 
-g["rev_load_slow!"]    = @benchmarkable perf_rev_load_slow!(fill!($v, $n))
-g["rev_load_fast!"]    = @benchmarkable perf_rev_load_fast!(fill!($v, $n))
-g["rev_loadmul_slow!"] = @benchmarkable perf_rev_loadmul_slow!(fill!($v, $n), $v)
-g["rev_loadmul_fast!"] = @benchmarkable perf_rev_loadmul_fast!(fill!($v, $n), $v)
+g["rev_load_slow!"]    = @benchmarkable perf_rev_load_slow!(fill!(v, n)) setup=(v=samerand(10^6); n=samerand())
+g["rev_load_fast!"]    = @benchmarkable perf_rev_load_fast!(fill!(v, n)) setup=(v=samerand(10^6); n=samerand())
+g["rev_loadmul_slow!"] = @benchmarkable perf_rev_loadmul_slow!(fill!(v, n), v) setup=(v=samerand(10^6); n=samerand())
+g["rev_loadmul_fast!"] = @benchmarkable perf_rev_loadmul_fast!(fill!(v, n), v) setup=(v=samerand(10^6); n=samerand())
+
 
 # #9622 #
 #-------#
@@ -135,11 +148,12 @@ perf_setindex!(A, val, inds) = setindex!(A, val, inds...)
 
 g = addgroup!(SUITE, "setindex!", ["index"])
 
-for s in (1, 2, 3, 4, 5)
-    A = samerand(Float64, ntuple(one, s)...)
-    y = one(eltype(A))
-    i = length(A)
-    g["setindex!", ndims(A)] = @benchmarkable perf_setindex!(fill!($A, $y), $y, $i)
+for nd in (1, 2, 3, 4, 5)
+    g["setindex!", nd] = @benchmarkable perf_setindex!(fill!(A, y), y, i) setup=begin
+        A = samerand(Float64, ntuple(one, $nd)...)
+        y = one(eltype(A))
+        i = length(A)
+    end
 end
 
 ###############################
@@ -153,21 +167,26 @@ end
 
 include("subarray.jl")
 
-n = samerand()
-
 g = addgroup!(SUITE, "subarray", ["lucompletepiv", "gramschmidt"])
 
 for s in (100, 250, 500, 1000)
-    m = samerand(s, s)
-    g["lucompletepivCopy!", s] = @benchmarkable perf_lucompletepivCopy!(fill!($m, $n))
-    g["lucompletepivSub!", s]  = @benchmarkable perf_lucompletepivSub!(fill!($m, $n))
+    g["lucompletepivCopy!", s] = @benchmarkable perf_lucompletepivCopy!(fill!(m, n)) setup=begin
+        n = samerand()
+        m = samerand($s, $s)
+    end
+    g["lucompletepivSub!", s]  = @benchmarkable perf_lucompletepivSub!(fill!(m, n)) setup=begin
+        n = samerand()
+        m = samerand($s, $s)
+    end
 end
 
 # Gram-Schmidt orthonormalization, using views to operate on matrix slices.
 
 for s in (100, 250, 500, 1000)
-    m = samerand(s, s)
-    g["gramschmidt!", s] = @benchmarkable perf_gramschmidt!(fill!($m, $n))
+    g["gramschmidt!", s] = @benchmarkable perf_gramschmidt!(fill!(m, n)) setup=begin
+        n = samerand()
+        m = samerand($s, $s)
+    end
 end
 
 #################
@@ -179,14 +198,13 @@ include("cat.jl")
 g = addgroup!(SUITE, "cat", ["index"])
 
 for s in (5, 500)
-    A = samerand(s, s)
-    g["hvcat", s]        = @benchmarkable perf_hvcat($A, $A)
-    g["hcat", s]         = @benchmarkable perf_hcat($A, $A)
-    g["vcat", s]         = @benchmarkable perf_vcat($A, $A)
+    g["hvcat", s]        = @benchmarkable perf_hvcat(A, A) setup=(A=samerand($s, $s))
+    g["hcat", s]         = @benchmarkable perf_hcat(A, A) setup=(A=samerand($s, $s))
+    g["vcat", s]         = @benchmarkable perf_vcat(A, A) setup=(A=samerand($s, $s))
     g["catnd", s]        = @benchmarkable perf_catnd($s)
-    g["hvcat_setind", s] = @benchmarkable perf_hvcat_setind($A, $A)
-    g["hcat_setind", s]  = @benchmarkable perf_hcat_setind($A, $A)
-    g["vcat_setind", s]  = @benchmarkable perf_vcat_setind($A, $A)
+    g["hvcat_setind", s] = @benchmarkable perf_hvcat_setind(A, A) setup=(A=samerand($s, $s))
+    g["hcat_setind", s]  = @benchmarkable perf_hcat_setind(A, A) setup=(A=samerand($s, $s))
+    g["vcat_setind", s]  = @benchmarkable perf_vcat_setind(A, A) setup=(A=samerand($s, $s))
     g["catnd_setind", s] = @benchmarkable perf_catnd_setind($s)
 end
 
@@ -206,11 +224,10 @@ end
 g = addgroup!(SUITE, "growth", ["push!", "append!", "prepend!"])
 
 for s in (8, 256, 2048)
-    vs = samerand(s)
-    g["push_single!", s]   = @benchmarkable push!(x, $(samerand()))     setup=(x = copy($vs))
-    g["push_multiple!", s] = @benchmarkable perf_push_multiple!(x, $vs) setup=(x = copy($vs))
-    g["append!", s]        = @benchmarkable append!(x, $vs)             setup=(x = copy($vs))
-    g["prerend!", s]       = @benchmarkable prepend!(x, $vs)            setup=(x = copy($vs))
+    g["push_single!", s]   = @benchmarkable push!(x, y)     setup=(x=samerand($s); y=samerand())
+    g["push_multiple!", s] = @benchmarkable perf_push_multiple!(x, vs) setup=(x=samerand($s); vs=copy(x))
+    g["append!", s]        = @benchmarkable append!(x, vs)             setup=(x=samerand($s); vs=copy(x))
+    g["prerend!", s]       = @benchmarkable prepend!(x, vs)            setup=(x=samerand($s); vs=copy(x))
 end
 
 ##########################
@@ -221,18 +238,18 @@ perf_compr_collect(X) = [x for x in X]
 perf_compr_iter(X) = [sin(x) + x^2 - 3 for x in X]
 perf_compr_index(X) = [sin(X[i]) + (X[i])^2 - 3 for i in eachindex(X)]
 
-ls = range(0, stop=1, length=10^7)
-rg = 0.0:(10.0^(-7)):1.0
-arr = collect(ls)
+getls() = range(0, stop=1, length=10^7)
+getrg() = 0.0:(10.0^(-7)):1.0
+getarr() = collect(getls())
 
 g = addgroup!(SUITE, "comprehension", ["iteration", "index", "collect", "range"])
 
-for X in (ls, rg, arr)
-    T = string(typeof(X))
-    g["collect", T] = @benchmarkable collect($X)
-    g["comprehension_collect", T]   = @benchmarkable perf_compr_collect($X)
-    g["comprehension_iteration", T] = @benchmarkable perf_compr_iter($X)
-    g["comprehension_indexing", T]  = @benchmarkable perf_compr_index($X) time_tolerance=0.30
+for getX in (getls, getrg, getarr)
+    T = string(typeof(getX()))
+    g["collect", T] = @benchmarkable collect(X) setup=(X=$getX())
+    g["comprehension_collect", T]   = @benchmarkable perf_compr_collect(X) setup=(X=$getX())
+    g["comprehension_iteration", T] = @benchmarkable perf_compr_iter(X) setup=(X=$getX())
+    g["comprehension_indexing", T]  = @benchmarkable perf_compr_index(X) setup=(X=$getX()) time_tolerance=0.30
 end
 
 ###############################
@@ -253,20 +270,17 @@ function perf_true_load!(result)
     return result
 end
 
-n, vals = 10^6, -3:3
-a, b = samerand(vals, n), samerand(vals)
-
-boolarr = Vector{Bool}(undef, n)
-bitarr = BitArray(undef, n)
-
 g = addgroup!(SUITE, "bool", ["index", "bitarray", "fill!"])
 
-g["bitarray_bool_load!"]  = @benchmarkable perf_bool_load!($bitarr, $a, $b)
-g["boolarray_bool_load!"] = @benchmarkable perf_bool_load!($boolarr, $a, $b)
-g["bitarray_true_load!"]  = @benchmarkable perf_true_load!($bitarr)
-g["boolarray_true_load!"] = @benchmarkable perf_true_load!($boolarr)
-g["bitarray_true_fill!"]  = @benchmarkable fill!($bitarr, true)
-g["boolarray_true_fill!"] = @benchmarkable fill!($boolarr, true)
+let n = 10^6, vals = -3:3
+    ab(n) = samerand(vals, n), samerand(vals)
+    g["bitarray_bool_load!"]  = @benchmarkable perf_bool_load!(bitarr, a, b) setup=((a,b)=$ab($n); bitarr=BitArray(undef,$n))
+    g["boolarray_bool_load!"] = @benchmarkable perf_bool_load!(boolarr, a, b) setup=((a,b)=$ab($n); boolarr=Vector{Bool}(undef, $n))
+    g["bitarray_true_load!"]  = @benchmarkable perf_true_load!(bitarr) setup=(bitarr=BitArray(undef,$n))
+    g["boolarray_true_load!"] = @benchmarkable perf_true_load!(boolarr) setup=(boolarr=Vector{Bool}(undef, $n))
+    g["bitarray_true_fill!"]  = @benchmarkable fill!(bitarr, true) setup=(bitarr=BitArray(undef,$n))
+    g["boolarray_true_fill!"] = @benchmarkable fill!(boolarr, true) setup=(boolarr=Vector{Bool}(undef, $n))
+end
 
 
 ####################################
@@ -274,75 +288,79 @@ g["boolarray_true_fill!"] = @benchmarkable fill!($boolarr, true)
 ####################################
 
 function perf_convert!(a, x)
-    for i=1:length(x)
+    for i = 1:length(x)
         a[i] = x[i]
     end
     return a
 end
 
-x_int = samerand(1:1000000,100,100)
-x_float = 1.0 * x_int
-x_complex = x_float .+ 0.0im
-
 g = addgroup!(SUITE, "convert", ["Int"])
-g["Int", "Float64"] = @benchmarkable  perf_convert!($x_int, $x_float)
-g["Float64", "Int"] = @benchmarkable  perf_convert!($x_float, $x_int)
-g["Complex{Float64}", "Int"] = @benchmarkable  perf_convert!($x_complex, $x_int)
-g["Int", "Complex{Float64}"] = @benchmarkable  perf_convert!($x_int, $x_complex)
+g["Int", "Float64"] = @benchmarkable  perf_convert!(x_int, x_float) setup=(x_int=samerand(1:1000000,100,100); x_float=1.0x_int)
+g["Float64", "Int"] = @benchmarkable  perf_convert!(x_float, x_int) setup=(x_int=samerand(1:1000000,100,100); x_float=1.0x_int)
+g["Complex{Float64}", "Int"] = @benchmarkable  perf_convert!(x_complex, x_int) setup=(x_int=samerand(1:1000000,100,100); x_float=1.0x_int; x_complex=x_float .+ 0.0im)
+g["Int", "Complex{Float64}"] = @benchmarkable  perf_convert!(x_int, x_complex) setup=(x_int=samerand(1:1000000,100,100); x_float=1.0x_int; x_complex=x_float .+ 0.0im)
 
 
 ################
 # == and isequal
 ################
 
-x_range = 1:10_000
-x_vec = collect(x_range)
-
 g = addgroup!(SUITE, "equality", ["==", "isequal"])
 
 # Only test cases which do not short-circuit, else performance
 # depends too much on the data
-for x in (x_range, x_vec, Int16.(x_range), Float64.(x_range), Float32.(x_range))
-    g["==", string(typeof(x))] = @benchmarkable $x == $(copy(x))
-    g["isequal", string(typeof(x))] = @benchmarkable isequal($x, $(copy(x)))
+let x_range = 1:10_000
+    for getx in (() -> x_range,
+              () -> collect(x_range),
+              () -> Int16.(x_range),
+              () -> Float64.(x_range),
+              () -> Float32.(x_range))
+        x = getx()
+        g["==", string(typeof(x))] = @benchmarkable x == y setup=(x=$getx(); y=copy(x))
+        g["isequal", string(typeof(x))] = @benchmarkable isequal(x, y) setup=(x=$getx(); y=copy(x))
 
-    g["==", string(typeof(x_vec), " == ", typeof(x))] =
-        @benchmarkable $x_vec == $x
-    g["isequal", string(typeof(x_vec), " isequal ", typeof(x))] =
-        @benchmarkable isequal($x_vec, $x)
+        x_vec = collect(x)
+        g["==", string(typeof(x_vec), " == ", typeof(x))] =
+            @benchmarkable x_vec == x setup=(x=$getx(); x_vec=collect(x))
+        g["isequal", string(typeof(x_vec), " isequal ", typeof(x))] =
+            @benchmarkable isequal(x_vec, x) setup=(x=$getx(); x_vec=collect(x))
+    end
 end
 
-x_bool = fill(false, 10_000)
-x_bitarray = falses(10_000)
-g["==", "Vector{Bool}"] = @benchmarkable $x_bool == $(copy(x_bool))
-g["isequal", "Vector{Bool}"] = @benchmarkable isequal($x_bool, $(copy(x_bool)))
-g["==", "BitArray"] = @benchmarkable $x_bitarray == $(copy(x_bitarray))
-g["isequal", "BitArray"] = @benchmarkable isequal($x_bitarray, $(copy(x_bitarray)))
+g["==", "Vector{Bool}"] = @benchmarkable x == y setup=(x=fill(false, 10_000); y=copy(x))
+g["isequal", "Vector{Bool}"] = @benchmarkable isequal(x, y) setup=(x=fill(false, 10_000); y=copy(x))
+g["==", "BitArray"] = @benchmarkable x == y setup=(x=falses(10_000); y=copy(x))
+g["isequal", "BitArray"] = @benchmarkable isequal(x, y) setup=(x=fill(false, 10_000); y=copy(x))
 
 ###########
 # any & all
 ###########
 
-x_false = fill(false, 10_000)
-x_true = fill(true, 10_000)
+getx_false() = fill(false, 10_000)
+getx_true() = fill(true, 10_000)
 
 g = addgroup!(SUITE, "any/all", ["any", "all"])
 
 # Only test cases which do not short-circuit, else performance
 # depends too much on the data
-g["any", "Vector{Bool}"] = @benchmarkable any($x_false)
-g["all", "Vector{Bool}"] = @benchmarkable all($x_true)
-g["any", "BitArray"] = @benchmarkable any($(BitArray(x_false)))
-g["all", "BitArray"] = @benchmarkable all($(BitArray(x_true)))
+g["any", "Vector{Bool}"] = @benchmarkable any(x) setup=(x=getx_false())
+g["all", "Vector{Bool}"] = @benchmarkable all(x) setup=(x=getx_true())
+g["any", "BitArray"] = @benchmarkable any(x) setup=(x=BitArray(getx_false()))
+g["all", "BitArray"] = @benchmarkable all(x) setup=(x=BitArray(getx_true()))
 
-x_range = 1:10_000
-for x in (x_range, collect(x_range), Int16.(x_range), Float64.(x_range), Float32.(x_range))
-    g["any", string(typeof(x))] = @benchmarkable any(v -> v < 0, $x)
-    g["all", string(typeof(x))] = @benchmarkable all(v -> v > 0, $x)
+let x_range = 1:10_000
+    for getx in (() -> x_range,
+                 () -> collect(x_range),
+                 () -> Int16.(x_range),
+                 () -> Float64.(x_range),
+                 () -> Float32.(x_range))
+        x = getx()
+        g["any", string(typeof(x))] = @benchmarkable any(v -> v < 0, x) setup=(x=$getx())
+        g["all", string(typeof(x))] = @benchmarkable all(v -> v > 0, x) setup=(x=$getx())
 
-    gen = (xi for xi in x)
-    g["any", string(typeof(x), " generator")] = @benchmarkable any(v -> v < 0, $gen)
-    g["all", string(typeof(x), " generator")] = @benchmarkable all(v -> v > 0, $gen)
+        g["any", string(typeof(x), " generator")] = @benchmarkable any(v -> v < 0, gen) setup=(gen=(xi for xi in $getx()))
+        g["all", string(typeof(x), " generator")] = @benchmarkable all(v -> v > 0, gen) setup=(gen=(xi for xi in $getx()))
+    end
 end
 
 ###########
@@ -351,27 +369,23 @@ end
 
 g = addgroup!(SUITE, "accumulate", ["accumulate","cumsum"])
 
-g["accumulate", "Float64"] = @benchmarkable accumulate(+, $afloat)
-g["accumulate", "Int"] = @benchmarkable accumulate(+, $aint)
+g["accumulate", "Float64"] = @benchmarkable accumulate(+, a) setup=(a=getafloat())
+g["accumulate", "Int"] = @benchmarkable accumulate(+, a) setup=(a=getaint())
 
-g["cumsum", "Float64"] = @benchmarkable cumsum($afloat)
-g["cumsum", "Int"] = @benchmarkable cumsum($aint)
+g["cumsum", "Float64"] = @benchmarkable cumsum(a) setup=(a=getafloat())
+g["cumsum", "Int"] = @benchmarkable cumsum(a) setup=(a=getaint())
 
-resafloat = similar(afloat)
-resaint = similar(aint)
+g["accumulate!", "Float64"] = @benchmarkable accumulate!(+, res, a) setup=(a=getafloat(); res=similar(a))
+g["accumulate!", "Int"] = @benchmarkable accumulate!(+, res, a) setup=(a=getaint(); res=similar(a))
 
-g["accumulate!", "Float64"] = @benchmarkable accumulate!(+, $resafloat, $afloat)
-g["accumulate!", "Int"] = @benchmarkable accumulate!(+, $resaint, $aint)
+g["cumsum!", "Float64"] = @benchmarkable cumsum!(res, a) setup=(a=getafloat(); res=similar(a))
+g["cumsum!", "Int"] = @benchmarkable cumsum!(res, a) setup=(aint=getaint(); a=aint.÷length(aint); res=similar(a))
 
-g["cumsum!", "Float64"] = @benchmarkable cumsum!($resafloat, $afloat)
-g["cumsum!", "Int"] = @benchmarkable cumsum!($resaint, $(aint.÷length(aint)))
+getmfloat() = samerand(10^3,10^3)
+g["cumsum", "Float64", "dim1"] = @benchmarkable cumsum(mfloat, dims=1) setup=(mfloat=getmfloat())
+g["cumsum", "Float64", "dim2"] = @benchmarkable cumsum(mfloat, dims=2) setup=(mfloat=getmfloat())
 
-mfloat = samerand(10^3,10^3)
-g["cumsum", "Float64", "dim1"] = @benchmarkable cumsum($mfloat, dims=1)
-g["cumsum", "Float64", "dim2"] = @benchmarkable cumsum($mfloat, dims=2)
-
-resmfloat = similar(mfloat)
-g["cumsum!", "Float64", "dim1"] = @benchmarkable cumsum!($resmfloat, $mfloat, dims=1)
-g["cumsum!", "Float64", "dim2"] = @benchmarkable cumsum!($resmfloat, $mfloat, dims=2)
+g["cumsum!", "Float64", "dim1"] = @benchmarkable cumsum!(res, mfloat, dims=1) setup=(mfloat=getmfloat(); res=similar(mfloat))
+g["cumsum!", "Float64", "dim2"] = @benchmarkable cumsum!(res, mfloat, dims=2) setup=(mfloat=getmfloat(); res=similar(mfloat))
 
 end # module

--- a/src/array/sumindex.jl
+++ b/src/array/sumindex.jl
@@ -292,39 +292,38 @@ Base.zero(::Type{PairVals{T}}) where T = PairVals(zero(T), zero(T))
 Base.:(+)(p1::PairVals, p2::PairVals) = PairVals(p1.a + p2.a, p1.b + p2.b)
 Base.:(*)(p1::PairVals, p2::PairVals) = PairVals(p1.a * p2.a, p1.b * p2.b)
 
-function makearrays(::Type{T}, r::Integer, c::Integer) where T
+# return the ith array in our set of definition
+function makearrays(::Type{T}, r::Integer, c::Integer, i::Int) where T
     A = samerand(T, r, c)
+    ((i -= 1) == 0) && return A
     B = similar(A, r+1, c+1)
     B[1:r, 1:c] = A
     AS = ArrayLS(B)
-    ASS = ArrayLSLS(B)
-    AF = ArrayLF(A)
-    Astrd = ArrayStrides(A)
-    Astrd1 = ArrayStrides1(A)
+    ((i -= 1) == 0) && return AS
+    ((i -= 1) == 0) && return ArrayLSLS(B)
+    ((i -= 1) == 0) && return ArrayLF(A)
+    #Astrd = ArrayStrides(A)
+    #Astrd1 = ArrayStrides1(A)
     B = samerand(T, r+1, c+2)
     # And views thereof
-    Asub = view(B, 1:r, 2:c+1)
-    Asub2 = view(A, :, :)
-    Asub3 = view(AS, :, :)
+    ((i -= 1) == 0) && return view(B, 1:r, 2:c+1)
+    ((i -= 1) == 0) && return view(A, :, :)
+    ((i -= 1) == 0) && return view(AS, :, :)
     C = samerand(T, 4, r, c)
-    Asub4 = view(C, 1, :, :)
-    Asub5 = view(ArrayLS(C), 1, :, :)
-    Asub6 = view(reshape(view(C, :, :, :), Val(2)), :, 2:c+1)
-    Asub7 = view(reshape(view(ArrayLS(C), :, :, :), Val(2)), :, 2:c+1)
-    arrays = (A, AF, AS, ASS, Asub, Asub2, Asub3, Asub4, Asub5, Asub6, Asub7)
+    ((i -= 1) == 0) && return view(C, 1, :, :)
+    ((i -= 1) == 0) && return view(ArrayLS(C), 1, :, :)
+    ((i -= 1) == 0) && return view(reshape(view(C, :, :, :), Val(2)), :, 2:c+1)
+    ((i -= 1) == 0) && return view(reshape(view(ArrayLS(C), :, :, :), Val(2)), :, 2:c+1)
     # ReinterpretArrays
-    if sizeof(T) < 8
-        Tw = widen(T)
-        Aw = samerand(Tw, r, c)
-        Awr = reinterpret(PairVals{T}, Aw)  # same size, with fields
-        arrays = (arrays..., Aw, Awr)
-    end
-    if iseven(r)
-        arrays = (arrays..., reinterpret(PairVals{T}, A))  # twice the size, with fields
-    end
+    @assert sizeof(T) < 8
+    Tw = widen(T)
+    Aw = samerand(Tw, r, c)
+    ((i -= 1) == 0) && return Aw
+    ((i -= 1) == 0) && return reinterpret(PairVals{T}, Aw)  # same size, with fields
+    @assert iseven(r)
+    ((i -= 1) == 0) && return reinterpret(PairVals{T}, A)  # twice the size, with fields
     if T === Int32
-        arrays = (arrays..., reinterpret(Float32, A))  # same size, no fields
+        ((i -= 1) == 0) && return reinterpret(Float32, A)
     end
-
-    return arrays
+    return -i
 end

--- a/src/sparse/SparseBenchmarks.jl
+++ b/src/sparse/SparseBenchmarks.jl
@@ -21,53 +21,54 @@ g = addgroup!(SUITE, "index")
 # vector #
 #--------#
 
-sizes = (10^3, 10^4, 10^5)
+getspvec(s) = samesprand(s, inv(sqrt(s)))
+getsplogvec(s) = samesprandbool(s, 1e-5)
 
-spvecs = map(s -> samesprand(s, inv(sqrt(s))), sizes)
-splogvecs = map(s -> samesprandbool(s, 1e-5), sizes)
-
-for (s, v, l) in zip(sizes, spvecs, splogvecs)
-    g["spvec", "array",   s] = @benchmarkable getindex($v, $(samerand(1:s, s)))
-    g["spvec", "integer", s] = @benchmarkable getindex($v, $(samerand(1:s)))
-    g["spvec", "range",   s] = @benchmarkable getindex($v, $(1:s))
-    g["spvec", "logical", s] = @benchmarkable getindex($v, $(samerand(Bool, s)))
-    # g["spvec", "splogical", s, nnz(v), nnz(l)] = @benchmarkable getindex($v, $l)
+let sizes = (10^3, 10^4, 10^5)
+for s in sizes
+    g["spvec", "array",   s] = @benchmarkable getindex(v, i) setup=(s=$s; v=getspvec(s); i=samerand(1:s, s))
+    g["spvec", "integer", s] = @benchmarkable getindex(v, i) setup=(s=$s; v=getspvec(s); i=samerand(1:s))
+    g["spvec", "range",   s] = @benchmarkable getindex(v, i) setup=(s=$s; v=getspvec(s); i=1:s)
+    g["spvec", "logical", s] = @benchmarkable getindex(v, i) setup=(s=$s; v=getspvec(s); i=samerand(Bool, s))
+    # g["spvec", "splogical", s, nnz(v), nnz(l)] = @benchmarkable getindex($v, $l) setup=(s=$s; v=getspvec(s); i=samerand(Bool, s); l=getsplogvec(s))
+end
 end
 
 # matrix #
 #--------#
 
-sizes = (10, 10^2, 10^3)
-inds = map(s -> samerand(1:s), sizes)
-matrices = map(s -> samesprand(s, s, inv(sqrt(s))), sizes)
-vectors = map(s -> samerand(1:s, s), sizes)
-logvecs = map(s -> samerand(Bool, s), sizes)
-splogmats = map(s -> samesprandbool(s, s, 1e-5), sizes)
-splogvecs = map(s -> samesprandbool(s, 1, 1e-5), sizes)
+getind(s) = samerand(1:s)
+getmatrix(s) = samesprand(s, s, inv(sqrt(s)))
+getvector(s) = samerand(1:s, s)
+getlogvec(s) = samerand(Bool, s)
+getsplogmat(s) = samesprandbool(s, s, 1e-5)
+getsplogvec(s) = samesprandbool(s, 1, 1e-5)
 
-for (s, m, v, l, sl, c) in zip(sizes, matrices, vectors, logvecs, splogvecs, inds)
-    g["spmat", "col", "array", s] = @benchmarkable getindex($m, $v, $c)
-    g["spmat", "col", "range", s] = @benchmarkable getindex($m, $(1:s), $c)
-    g["spmat", "col", "OneTo", s] = @benchmarkable getindex($m, $(Base.OneTo(s)), $c)
-    g["spmat", "col", "logical", s] = @benchmarkable getindex($m, $l, $c)
-    # g["spmat", "col", "splogical", s] = @benchmarkable getindex($m, $sl, $c)
+let sizes = (10, 10^2, 10^3)
+for s in sizes
+    g["spmat", "col", "array", s] = @benchmarkable getindex(m, v, c) setup=(s=$s; m=getmatrix(s); v=getvector(s); c=getind(s))
+    g["spmat", "col", "range", s] = @benchmarkable getindex(m, v, c) setup=(s=$s; m=getmatrix(s); v=1:s; c=getind(s))
+    g["spmat", "col", "OneTo", s] = @benchmarkable getindex(m, v, c) setup=(s=$s; m=getmatrix(s); v=Base.OneTo(s); c=getind(s))
+    g["spmat", "col", "logical", s] = @benchmarkable getindex(m, l, c) setup=(s=$s; m=getmatrix(s); l=getlogvec(s); c=getind(s))
+    # g["spmat", "col", "splogical", s] = @benchmarkable getindex(m, sl, c) setup=(s=$s; m=getmatrix(s); sl=getsplogvec(s); c=getind(s))
 end
 
-for (s, m, v, l, sl, r) in zip(sizes, matrices, vectors, logvecs, splogvecs, inds)
-    g["spmat", "row", "array", s] = @benchmarkable getindex($m, $r, $v)
-    g["spmat", "row", "range", s] = @benchmarkable getindex($m, $r, $(1:s))
-    g["spmat", "row", "OneTo", s] = @benchmarkable getindex($m, $r, $(Base.OneTo(s)))
-    g["spmat", "row", "logical", s] = @benchmarkable getindex($m, $r, $l)
-    # g["spmat", "row", "splogical", s] = @benchmarkable getindex($m, $r, $sl)
+for s in sizes
+    g["spmat", "row", "array", s] = @benchmarkable getindex(m, r, v) setup=(s=$s; m=getmatrix(s); v=getvector(s); r=getind(s))
+    g["spmat", "row", "range", s] = @benchmarkable getindex(m, r, v) setup=(s=$s; m=getmatrix(s); v=1:s; r=getind(s))
+    g["spmat", "row", "OneTo", s] = @benchmarkable getindex(m, r, v) setup=(s=$s; m=getmatrix(s); v=Base.OneTo(s); r=getind(s))
+    g["spmat", "row", "logical", s] = @benchmarkable getindex(m, r, l) setup=(s=$s; m=getmatrix(s); l=getlogvec(s); r=getind(s))
+    # g["spmat", "row", "splogical", s] = @benchmarkable getindex(m, r, sl) setup=(s=$s; m=getmatrix(s); sl=getsplogvec(s); r=getind(s))
 end
 
-for (s, m, v, l, sl, i) in zip(sizes, matrices, vectors, logvecs, splogmats, inds)
-    g["spmat", "array", s] = @benchmarkable getindex($m, $v, $v)
-    g["spmat", "integer", s] = @benchmarkable getindex($m, $i, $i)
-    g["spmat", "range", s] = @benchmarkable getindex($m, $(1:s), $(1:s))
-    g["spmat", "OneTo", s] = @benchmarkable getindex($m, $(Base.OneTo(s)), $(Base.OneTo(s)))
-    g["spmat", "logical", s] = @benchmarkable getindex($m, $l, $l)
-    g["spmat", "splogical", s] = @benchmarkable getindex($m, $sl)
+for s in sizes
+    g["spmat", "array", s] = @benchmarkable getindex(m, v, v) setup=(s=$s; m=getmatrix(s); v=getvector(s))
+    g["spmat", "integer", s] = @benchmarkable getindex(m, i, i) setup=(s=$s; m=getmatrix(s); i=getind(s))
+    g["spmat", "range", s] = @benchmarkable getindex(m, 1:s, 1:s) setup=(s=$s; m=getmatrix(s))
+    g["spmat", "OneTo", s] = @benchmarkable getindex(m, Base.OneTo(s), Base.OneTo(s)) setup=(s=$s; m=getmatrix(s))
+    g["spmat", "logical", s] = @benchmarkable getindex(m, l, l) setup=(s=$s; m=getmatrix(s); l=getlogvec(s))
+    g["spmat", "splogical", s] = @benchmarkable getindex(m, sl) setup=(s=$s; m=getmatrix(s); sl=getsplogmat(s))
+end
 end
 
 for b in values(g)
@@ -78,20 +79,16 @@ end
 # transpose (#14631) #
 ######################
 
-small_sqr = samesprand(600, 600, 0.01)
-small_rct = samesprand(600, 400, 0.01)
-large_sqr = samesprand(20000, 20000, 0.01)
-large_rct = samesprand(20000, 10000, 0.01)
-
 g = addgroup!(SUITE, "transpose", ["adjoint"])
 
-for m in (small_sqr, small_rct, large_sqr, large_rct)
-    cm = m + m*im
-    s = size(m)
-    g["transpose", s] = @benchmarkable transpose($m)
-    g["transpose!", s] = @benchmarkable transpose!($(copy(transpose(m))), $m)
-    g["adjoint", s] = @benchmarkable adjoint($cm)
-    g["adjoint!", s] = @benchmarkable adjoint!($(copy(transpose(cm))), $cm)
+for s in ((600, 600),
+          (600, 400),
+          (20000, 20000),
+          (20000, 10000))
+    g["transpose", s] = @benchmarkable transpose(m) setup=(m=samesprand($s[1], $s[2], 0.01))
+    g["transpose!", s] = @benchmarkable transpose!(mt, m) setup=(m=samesprand($s[1], $s[2], 0.01); mt=copy(transpose(m)))
+    g["adjoint", s] = @benchmarkable adjoint(cm) setup=(m=samesprand($s[1], $s[2], 0.01); cm=m + m*im)
+    g["adjoint!", s] = @benchmarkable adjoint!(cmt, cm) setup=(m=samesprand($s[1], $s[2], 0.01); cm=m + m*im; cmt=copy(transpose(cm)))
 end
 
 for b in values(g)
@@ -105,8 +102,8 @@ end
 g = addgroup!(SUITE, "arithmetic")
 
 # unary minus, julialang repo issue #19503 / fix #19530
-g["unary minus", size(small_sqr)] = @benchmarkable -$small_sqr
-g["unary minus", size(large_sqr)] = @benchmarkable -$large_sqr
+g["unary minus", (600, 600)] = @benchmarkable -m setup=(m=samesprand(600, 600, 0.01))
+g["unary minus", (20000, 20000)] = @benchmarkable -m setup=(m=samesprand(20000, 20000, 0.01))
 
 for b in values(g)
     b.params.time_tolerance = 0.3
@@ -118,17 +115,19 @@ end
 g = addgroup!(SUITE, "constructors")
 
 const UPLO = :U
+let sizes = (10, 10^2, 10^3)
 for s in sizes
     nz = floor(Int, 1e-4*s*s)
-    I = samerand(1:s, nz)
-    J = samerand(1:s, nz)
-    V = randvec(nz)
-    g["IV", s] = @benchmarkable sparsevec($I, $V)
-    g["IJV", s] = @benchmarkable sparse($I, $J, $V)
-    g["Diagonal", s] = @benchmarkable sparse($(Diagonal(randvec(s))))
-    g["Bidiagonal", s] = @benchmarkable sparse($(Bidiagonal(randvec(s), randvec(s-1), UPLO)))
-    g["Tridiagonal", s] = @benchmarkable sparse($(Tridiagonal(randvec(s-1), randvec(s), randvec(s-1))))
-    g["SymTridiagonal", s] = @benchmarkable sparse($(SymTridiagonal(randvec(s), randvec(s-1))))
+    getI() = samerand(1:s, nz)
+    getJ() = samerand(1:s, nz)
+    getV() = randvec(nz)
+    g["IV", s] = @benchmarkable sparsevec(I, V) setup=(I=$getI(); V=$getV())
+    g["IJV", s] = @benchmarkable sparse(I, J, V) setup=(I=$getI(); J=$getJ(); V=$getV())
+    g["Diagonal", s] = @benchmarkable sparse(D) setup=(D=Diagonal(randvec($s)))
+    g["Bidiagonal", s] = @benchmarkable sparse(B) setup=(B=Bidiagonal(randvec($s), randvec($s-1), UPLO))
+    g["Tridiagonal", s] = @benchmarkable sparse(T) setup=(T=Tridiagonal(randvec($s-1), randvec($s), randvec($s-1)))
+    g["SymTridiagonal", s] = @benchmarkable sparse(ST) setup=(ST=SymTridiagonal(randvec($s), randvec($s-1)))
+end
 end
 
 #########################
@@ -142,26 +141,23 @@ g = addgroup!(SUITE, "matmul")
 
 using LinearAlgebra: *, mul!
 
-function allocmats_ds(om, ok, on, s, nnzc, T)
-    m, k, n = map(x -> Int(s*x), (om, ok, on))
+function allocmats_ds(m, k, n, nnzc, T)
     densemat, sparsemat = samerand(T, m, k), samesprand(T, k, n, nnzc/k)
     tdensemat = transpose!(similar(densemat, reverse(size(densemat))), densemat)
     tsparsemat = transpose!(similar(sparsemat, reverse(size(sparsemat))), sparsemat)
     destmat = similar(densemat, m, n)
-    return m, k, n, destmat,
-        densemat, sparsemat,
-        tdensemat, tsparsemat
+    return destmat, densemat, sparsemat, tdensemat, tsparsemat
 end
-function allocmats_sd(om, ok, on, s, nnzc, T)
-    m, k, n = map(x -> Int(s*x), (om, ok, on))
+
+function allocmats_sd(m, k, n, nnzc, T)
     densemat, sparsemat = samerand(T, k, m), samesprand(T, n, k, nnzc/n)
     tdensemat = transpose!(similar(densemat, reverse(size(densemat))), densemat)
     tsparsemat = transpose!(similar(sparsemat, reverse(size(sparsemat))), sparsemat)
     destmat = similar(densemat, n, m)
-    return m, k, n, destmat,
-        densemat, sparsemat,
-        tdensemat, tsparsemat
+    return destmat, densemat, sparsemat, tdensemat, tsparsemat
 end
+
+getsizes(om, ok, on, s) = map(x -> Int(s*x), (om, ok, on))
 
 for (om, ok, on) in (# order of matmul dimensions m, k, and n
         (10^2, 10^2, 10^2),  # dense square * sparse square -> dense square
@@ -186,27 +182,71 @@ for (om, ok, on) in (# order of matmul dimensions m, k, and n
     # the sparse matrix has approximately 10 entries per column
     #
     # # out-of-place dense-sparse ops, transpose variants, i.e. A[t]_mul_B[t](dense, sparse)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 1/2, 4, Float64)
-    g["A_mul_B",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $sparsemat)
-    g["A_mul_Bt",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $(Transpose(tsparsemat)))
-    g["At_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($(Transpose(tdensemat)), $sparsemat)
-    g["At_mul_Bt", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($(Transpose(tdensemat)), $(Transpose(tsparsemat)))
+    m, k, n = getsizes(om, ok, on, 1/2)
+    g["A_mul_B",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *(densemat, sparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, Float64)
+    end
+    g["A_mul_Bt",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *(densemat, ttsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, Float64)
+        ttsparsemat = Transpose(tsparsemat)
+    end
+    g["At_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *(ttdensemat, sparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, Float64)
+        ttdensemat = Transpose(tdensemat)
+    end
+    g["At_mul_Bt", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *(ttdensemat, ttsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, Float64)
+        ttdensemat = Transpose(tdensemat)
+        ttsparsemat = Transpose(tsparsemat)
+    end
     # in-place dense-sparse -> dense ops, transpose variants, i.e. A[t]_mul[t]!(dense, dense, sparse)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 4, 12, Float64)
-    g["A_mul_B!",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $densemat, $sparsemat)
-    g["A_mul_Bt!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $densemat, $(Transpose(tsparsemat)))
-    g["At_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Transpose(tdensemat)), $sparsemat)
-    g["At_mul_Bt!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Transpose(tdensemat)), $(Transpose(tsparsemat)))
+    m, k, n = getsizes(om, ok, on, 4)
+    g["A_mul_B!",   "dense $(m)x$(k), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, densemat, sparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 12, Float64)
+    end
+    g["A_mul_Bt!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, densemat, ttsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 12, Float64)
+        ttsparsemat = Transpose(tsparsemat)
+    end
+    g["At_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, ttdensemat, sparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 12, Float64)
+        ttdensemat = Transpose(tdensemat)
+    end
+    g["At_mul_Bt!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, ttdensemat, ttsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 12, Float64)
+        ttdensemat = Transpose(tdensemat)
+        ttsparsemat = Transpose(tsparsemat)
+    end
     # out-of-place dense-sparse ops, adjoint variants, i.e. A[c]_mul_B[c](dense, sparse)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 1/2, 4, Complex{Float64})
-    g["A_mul_Bc",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($densemat, $(Adjoint(tsparsemat)))
-    g["Ac_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *($(Adjoint(tdensemat)), $sparsemat)
-    g["Ac_mul_Bc", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *($(Adjoint(tdensemat)), $(Adjoint(tsparsemat)))
+    m, k, n = getsizes(om, ok, on, 1/2)
+    g["A_mul_Bc",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *(densemat, atsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, ComplexF64)
+        atsparsemat = Adjoint(tsparsemat)
+    end
+    g["Ac_mul_B",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable *(atdensemat, sparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+    end
+    g["Ac_mul_Bc", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable *(atdensemat, atsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 4, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+        atsparsemat = Adjoint(tsparsemat)
+    end
     # in-place dense-sparse -> dense ops, adjoint variants, i.e. A[c]_mul[c]!(dense, dense, sparse)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds(om, ok, on, 2, 8, Complex{Float64})
-    g["A_mul_Bc!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $densemat, $(Adjoint(tsparsemat)))
-    g["Ac_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Adjoint(tdensemat)), $sparsemat)
-    g["Ac_mul_Bc!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!($destmat, $(Adjoint(tdensemat)), $(Adjoint(tsparsemat)))
+    m, k, n = getsizes(om, ok, on, 2)
+    g["A_mul_Bc!",  "dense $(m)x$(k), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, densemat, atsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 8, ComplexF64)
+        atsparsemat = Adjoint(tsparsemat)
+    end
+    g["Ac_mul_B!",  "dense $(k)x$(m), sparse $(k)x$(n) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, atdensemat, sparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 8, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+    end
+    g["Ac_mul_Bc!", "dense $(k)x$(m), sparse $(n)x$(k) -> dense $(m)x$(n)"] = @benchmarkable mul!(destmat, atdensemat, atsparsemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_ds($m, $k, $n, 8, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+        atsparsemat = Adjoint(tsparsemat)
+    end
     #
     # for A[t|c]_mul_B[t|c][!]([dense,], sparse, dense) kernels,
     # the sparse matrix is n-by-k, or k-by-n for B(c|t) operations
@@ -215,27 +255,71 @@ for (om, ok, on) in (# order of matmul dimensions m, k, and n
     # the sparse matrix has approximately 10 entries per column
     #
     # out-of-place sparse-dense ops, transpose variants, i.e. A[t]_mul_B[t](sparse, dense)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 1/2, 4, Complex{Float64})
-    g["A_mul_B",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $densemat)
-    g["A_mul_Bt",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $(Transpose(tdensemat)))
-    g["At_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($(Transpose(tsparsemat)), $densemat)
-    g["At_mul_Bt", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($(Transpose(tsparsemat)), $(Transpose(tdensemat)))
+    m, k, n = getsizes(om, ok, on, 1/2)
+    g["A_mul_B",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *(sparsemat, densemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+    end
+    g["A_mul_Bt",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *(sparsemat, ttdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+        ttdensemat = Transpose(tdensemat)
+    end
+    g["At_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *(ttsparsemat, densemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+        ttsparsemat = Transpose(tsparsemat)
+    end
+    g["At_mul_Bt", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *(ttsparsemat, ttdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+        ttdensemat = Transpose(tdensemat)
+        ttsparsemat = Transpose(tsparsemat)
+    end
     # in-place sparse-dense -> dense ops, transpose variants, i.e. A[t|c]_mul_B[t|c]!(dense, sparse, dense)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 4, 12, Complex{Float64})
-    g["A_mul_B!",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $sparsemat, $densemat)
-    g["A_mul_Bt!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $sparsemat, $(Transpose(tdensemat)))
-    g["At_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Transpose(tsparsemat)), $densemat)
-    g["At_mul_Bt!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Transpose(tsparsemat)), $(Transpose(tdensemat)))
+    m, k, n = getsizes(om, ok, on, 4)
+    g["A_mul_B!",   "sparse $(n)x$(k), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, sparsemat, densemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 12, ComplexF64)
+    end
+    g["A_mul_Bt!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, sparsemat, ttdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 12, ComplexF64)
+        ttdensemat = Transpose(tdensemat)
+    end
+    g["At_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, ttsparsemat, densemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 12, ComplexF64)
+        ttsparsemat = Transpose(tsparsemat)
+    end
+    g["At_mul_Bt!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, ttsparsemat, ttdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 12, ComplexF64)
+        ttdensemat = Transpose(tdensemat)
+        ttsparsemat = Transpose(tsparsemat)
+    end
     # out-of-place sparse-dense ops, adjoint variants, i.e. A[c]_mul_B[c](sparse, dense)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 1/2, 4, Complex{Float64})
-    g["A_mul_Bc",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($sparsemat, $(Adjoint(tdensemat)))
-    g["Ac_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *($(Adjoint(tsparsemat)), $densemat)
-    g["Ac_mul_Bc", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *($(Adjoint(tsparsemat)), $(Adjoint(tdensemat)))
+    m, k, n = getsizes(om, ok, on, 1/2)
+    g["A_mul_Bc",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *(sparsemat, atdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+    end
+    g["Ac_mul_B",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable *(atsparsemat, densemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+        atsparsemat = Adjoint(tsparsemat)
+    end
+    g["Ac_mul_Bc", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable *(atsparsemat, atdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 4, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+        atsparsemat = Adjoint(tsparsemat)
+    end
     # in-place sparse-dense -> dense ops, adjoint variants, i.e. A[t|c]_mul_B[t|c]!(dense, sparse, dense)
-    m, k, n, destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd(om, ok, on, 2, 8, Complex{Float64})
-    g["A_mul_Bc!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $sparsemat, $(Adjoint(tdensemat)))
-    g["Ac_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Adjoint(tsparsemat)), $densemat)
-    g["Ac_mul_Bc!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!($destmat, $(Adjoint(tsparsemat)), $(Adjoint(tdensemat)))
+    m, k, n = getsizes(om, ok, on, 2)
+    g["A_mul_Bc!",  "sparse $(n)x$(k), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, sparsemat, atdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 8, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+    end
+    g["Ac_mul_B!",  "sparse $(k)x$(n), dense $(k)x$(m) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, atsparsemat, densemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 8, ComplexF64)
+        atsparsemat = Adjoint(tsparsemat)
+    end
+    g["Ac_mul_Bc!", "sparse $(k)x$(n), dense $(m)x$(k) -> dense $(n)x$(m)"] = @benchmarkable mul!(destmat, atsparsemat, atdensemat) setup=begin
+        destmat, densemat, sparsemat, tdensemat, tsparsemat = allocmats_sd($m, $k, $n, 8, ComplexF64)
+        atdensemat = Adjoint(tdensemat)
+        atsparsemat = Adjoint(tsparsemat)
+    end
 end
 
 for b in values(g)
@@ -247,10 +331,14 @@ end
 # sparse matvec #
 #################
 g = addgroup!(SUITE, "sparse matvec")
-B = randn(100000, 100)
-A = sprand(100000, 100000, 0.00001)
-g["non-adjoint"] = @benchmarkable A * B
-g["adjoint"] = @benchmarkable A' * B
+g["non-adjoint"] = @benchmarkable A * B setup=begin
+    B = randn(100000, 100)
+    A = sprand(100000, 100000, 0.00001)
+end
+g["adjoint"] = @benchmarkable A' * B setup=begin
+    B = randn(100000, 100)
+    A = sprand(100000, 100000, 0.00001)
+end
 
 #################
 # sparse solves #
@@ -258,26 +346,26 @@ g["adjoint"] = @benchmarkable A' * B
 g = addgroup!(SUITE, "sparse solves")
 # Problem similar to issue #30288
 let m = 10000, n = 9000
-    A = spdiagm(0 => fill(2.0, m),
-               -1 => fill(1.0, m - 1),
-                1 => fill(1.0, m - 1),
-              360 => fill(1.0, m - 360))[:, 1:n]
-    AtA = A'A
-    b   = ones(m)
-    B   = ones(m, 2)
-    Atb = A'b
-    AtB = A'B
+    getA() = spdiagm(0 => fill(2.0, m),
+                    -1 => fill(1.0, m - 1),
+                     1 => fill(1.0, m - 1),
+                   360 => fill(1.0, m - 360))[:, 1:n]
+    getAtA() = (A=getA(); A'A)
+    getb()   = ones(m)
+    getB()   = ones(m, 2)
+    getAtb() = getA()'getb()
+    getAtB() = getA()'getB()
 
-    g["least squares (default), vector rhs"]  = @benchmarkable         $A\$b
-    g["least squares (default), matrix rhs"]  = @benchmarkable         $A\$B
-    g["least squares (qr), vector rhs"]   = @benchmarkable     qr($A)\$b
-    g["least squares (qr), matrix rhs"]   = @benchmarkable     qr($A)\$B
-    g["square system (default), vector rhs"]  = @benchmarkable       $AtA\$Atb
-    g["square system (default), matrix rhs"]  = @benchmarkable       $AtA\$AtB
-    g["square system (ldlt), vector rhs"] = @benchmarkable ldlt($AtA)\$Atb
-    g["square system (ldlt), matrix rhs"] = @benchmarkable ldlt($AtA)\$AtB
-    g["square system (lu), vector rhs"]   = @benchmarkable   lu($AtA)\$Atb
-    g["square system (lu), matrix rhs"]   = @benchmarkable   lu($AtA)\$AtB
+    g["least squares (default), vector rhs"] = @benchmarkable A\b setup=(A=$getA(); b=$getb())
+    g["least squares (default), matrix rhs"] = @benchmarkable A\B setup=(A=$getA(); B=$getB())
+    g["least squares (qr), vector rhs"] = @benchmarkable qr(A)\b setup=(A=$getA(); b=$getb())
+    g["least squares (qr), matrix rhs"] = @benchmarkable qr(A)\B setup=(A=$getA(); B=$getB())
+    g["square system (default), vector rhs"] = @benchmarkable AtA\Atb setup=(AtA=$getAtA(); Atb=$getAtb())
+    g["square system (default), matrix rhs"] = @benchmarkable AtA\AtB setup=(AtA=$getAtA(); AtB=$getAtB())
+    g["square system (ldlt), vector rhs"] = @benchmarkable ldlt(AtA)\Atb setup=(AtA=$getAtA(); Atb=$getAtb())
+    g["square system (ldlt), matrix rhs"] = @benchmarkable ldlt(AtA)\AtB setup=(AtA=$getAtA(); AtB=$getAtB())
+    g["square system (lu), vector rhs"] = @benchmarkable lu(AtA)\Atb setup=(AtA=$getAtA(); Atb=$getAtb())
+    g["square system (lu), matrix rhs"] = @benchmarkable lu(AtA)\AtB setup=(AtA=$getAtA(); AtB=$getAtB())
 end
 
 end # module


### PR DESCRIPTION
This fixes all of Sparse, IO, Array, and Misc to save about 2 GB for a 1000x improvement on those
```
julia> varinfo(BaseBenchmarks, all=true, sortby=:size)
  name                           size summary                                               
  ––––––––––––––––––––––– ––––––––––– ––––––––––––––––––––––––––––––––––––––––––––––––––––––
  BaseBenchmarks          272.275 MiB Module                                                
  SUITE                   265.295 MiB 23-element BenchmarkGroup([])                         
  LinAlgBenchmarks        216.710 MiB Module                                                
  BroadcastBenchmarks      30.804 MiB Module                                                
  UnionBenchmarks           8.505 MiB Module                                                
  SIMDBenchmarks            5.948 MiB Module                                                
  CollectionBenchmarks      4.351 MiB Module                                                
  ProblemBenchmarks         2.576 MiB Module                                                
  InferenceBenchmarks       2.078 MiB Module                                                
  ArrayBenchmarks           1.464 MiB Module                                                
  MiscellaneousBenchmarks 987.657 KiB Module                                                
  ShootoutBenchmarks      971.345 KiB Module                                                
  TupleBenchmarks         913.608 KiB Module                                                
  RandomBenchmarks        640.623 KiB Module                                                
  AllocBenchmarks         610.874 KiB Module                                                
  ScalarBenchmarks        537.010 KiB Module                                                
  SparseBenchmarks        416.740 KiB Module                                                
  StringBenchmarks        333.805 KiB Module                                                
  SortBenchmarks          150.063 KiB Module                                                
  FindBenchmarks          124.890 KiB Module                                                
  DatesBenchmarks         118.167 KiB Module                                                
  IOBenchmarks             71.189 KiB Module                                                
  MicroBenchmarks          52.814 KiB Module                                                
  ParallelBenchmarks        7.098 KiB Module                                                
  FrontendBenchmarks        5.248 KiB Module                                                
```