### PR TITLE
random: fix 32-bit integer overflow in RangeGenerator setup

### DIFF
--- a/src/array/ArrayBenchmarks.jl
+++ b/src/array/ArrayBenchmarks.jl
@@ -170,6 +170,9 @@ include("subarray.jl")
 g = addgroup!(SUITE, "subarray", ["lucompletepiv", "gramschmidt"])
 
 for s in (100, 250, 500, 1000)
+    # The 1000×1000 case allocates >2 GB per evaluation, which overflows
+    # BenchmarkTools' 32-bit (Int32) memory counter, so restrict it to 64-bit.
+    s == 1000 && Sys.WORD_SIZE != 64 && continue
     g["lucompletepivCopy!", s] = @benchmarkable perf_lucompletepivCopy!(fill!(m, n)) setup=begin
         n = samerand()
         m = samerand($s, $s)

--- a/src/random/RandomBenchmarks.jl
+++ b/src/random/RandomBenchmarks.jl
@@ -41,7 +41,7 @@ for T in INTS
     tstr = string(T)
     onestr = string(one(T))
     for n in T[filter(x -> T === BigInt || x <= typemax(T),
-                      [1, 2^32-1, b2^32+1, b2^64-1, b2^64, b2^127, b2^10000]);]
+                      [1, b2^32-1, b2^32+1, b2^64-1, b2^64, b2^127, b2^10000]);]
         nstr = n == b2^10000 ? "2^10000" : string(n)
         g["RangeGenerator", tstr, "$onestr:$nstr"] = @benchmarkable RangeGenerator($(T(1):n))
         g["rand", "MersenneTwister", tstr, "RangeGenerator($onestr:$nstr)"] =

--- a/src/sort/SortBenchmarks.jl
+++ b/src/sort/SortBenchmarks.jl
@@ -76,7 +76,11 @@ let g = addgroup!(SUITE, "issues")
     g["partialsort(rand(10_000), 10_000)"] = @benchmarkable partialsort(x, 10_000) setup=(x=rand(10_000))
 
     # 47715
-    g["sort(rand(10^8))"] = @benchmarkable sort(x) setup=(x=rand(10^8))
+    # 10^8 Float64 (~0.8 GB) plus the sort's working buffer exhausts a 32-bit
+    # address space, so restrict this case to 64-bit.
+    if Sys.WORD_SIZE == 64
+        g["sort(rand(10^8))"] = @benchmarkable sort(x) setup=(x=rand(10^8))
+    end
 
     # 47766
     g["partialsort!(rand(10_000), 1:3, rev=true)"] = @benchmarkable partialsort!(x, 1:3; rev=true) setup=(x=rand(10_000)) evals=1


### PR DESCRIPTION
The value list feeding the RangeGenerator/rand benchmarks used the literal `2^32-1`. On 32-bit platforms `Int === Int32`, so this overflows to `-1`, which the `x <= typemax(T)` filter then keeps for narrow integer types. Constructing `RangeGenerator(T(1):-1)` builds an empty range, which throws `ArgumentError: collection must be non-empty` at load time on Julia 1.12, failing the x86 CI job. Compute the bound as `b2^32-1` (BigInt) so it equals 4294967295 on all platforms and is correctly filtered out for narrow types.